### PR TITLE
Allow a user to login to non "main" firewall

### DIFF
--- a/src/Browser/KernelBrowser.php
+++ b/src/Browser/KernelBrowser.php
@@ -57,7 +57,7 @@ class KernelBrowser extends BrowserKitBrowser implements ProfileAware
         return $this;
     }
 
-    final public function actingAs(UserInterface $user, string $firewall = null): self
+    final public function actingAs(UserInterface $user, ?string $firewall = null): self
     {
         if (null === $firewall) {
             $this->inner()->loginUser($user);

--- a/src/Browser/KernelBrowser.php
+++ b/src/Browser/KernelBrowser.php
@@ -57,9 +57,13 @@ class KernelBrowser extends BrowserKitBrowser implements ProfileAware
         return $this;
     }
 
-    final public function actingAs(UserInterface $user): self
+    final public function actingAs(UserInterface $user, string $firewall = null): self
     {
-        $this->inner()->loginUser($user);
+        if (null === $firewall) {
+            $this->inner()->loginUser($user);
+        } else {
+            $this->inner()->loginUser($user, $firewall);
+        }
 
         return $this;
     }


### PR DESCRIPTION
If your firewall is not named "main". 

The current implementation allows us not to specify the name of the default firewall, we leave that to `KernelBrowser`. 