### PR TITLE
Access "console.log" in PantherBrowser console

### DIFF
--- a/tests/Fixture/files/javascript.html
+++ b/tests/Fixture/files/javascript.html
@@ -31,6 +31,7 @@
 <hr>
 
 <h1>Console Log Test</h1>
+<button id="log">log</button>
 <button id="log-error">log error</button>
 <button id="throw-error">throw error</button>
 <hr>
@@ -61,6 +62,9 @@
         });
         $('#toggle').click(function() {
             $('#toggle-box').toggle();
+        });
+        $('#log').click(function() {
+            console.log('console.log message');
         });
         $('#log-error').click(function() {
             console.error('console.error message');

--- a/tests/PantherBrowserTest.php
+++ b/tests/PantherBrowserTest.php
@@ -161,6 +161,22 @@ final class PantherBrowserTest extends TestCase
     /**
      * @test
      */
+    public function can_dump_console_log_with_console_log(): void
+    {
+        $output = self::catchVarDumperOutput(function() {
+            $this->browser()
+                ->visit('/javascript')
+                ->click('log')
+                ->dumpConsoleLog()
+            ;
+        });
+
+        $this->assertStringContainsString('console.log message', \json_encode($output, JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @test
+     */
     public function can_dump_console_log_with_throw_error(): void
     {
         $output = self::catchVarDumperOutput(function() {


### PR DESCRIPTION
Currently, `console.log('message')` is not captured by `PantherBrowser::dumpConsoleLog()`.

@weaverryan found [this resource](https://stackoverflow.com/questions/40538392/get-console-log-from-selenium-using-php-webdriver#answers), but I couldn't get it to work.