### PR TITLE
Access "throw 'string'" in PantherBrowser console

### DIFF
--- a/tests/Fixture/files/javascript.html
+++ b/tests/Fixture/files/javascript.html
@@ -33,6 +33,7 @@
 <h1>Console Log Test</h1>
 <button id="log-error">log error</button>
 <button id="throw-error">throw error</button>
+<button id="throw-raw">throw raw</button>
 <hr>
 
 <a style="display: none;" href="/page1">invisible link</a>
@@ -67,6 +68,9 @@
         });
         $('#throw-error').click(function() {
             throw new Error('error object message');
+        });
+        $('#throw-raw').click(function() {
+            throw 'raw error message';
         });
     });
 </script>

--- a/tests/PantherBrowserTest.php
+++ b/tests/PantherBrowserTest.php
@@ -188,6 +188,22 @@ final class PantherBrowserTest extends TestCase
         ;
     }
 
+    /**
+     * @test
+     */
+    public function can_dump_console_log_with_throw_raw(): void
+    {
+        $output = self::catchVarDumperOutput(function() {
+            $this->browser()
+                ->visit('/javascript')
+                ->click('throw raw')
+                ->dumpConsoleLog()
+            ;
+        });
+
+        $this->assertStringContainsString('raw error message', \json_encode($output, JSON_THROW_ON_ERROR));
+    }
+
     protected function browser(): PantherBrowser
     {
         return $this->pantherBrowser();


### PR DESCRIPTION
When using `throw 'message'` in your javascript, `PantherBrowser::dumpConsoleLog()` has an entry but it doesn't include "message", just "Uncaught".