### PR TITLE
Split HasBrowser trait while keeping the generic trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,22 +91,30 @@ There are several environment variables available to configure:
 
 This library provides 3 different "browsers":
 
-1. [KernelBrowser](#kernelbrowser): makes requests using your Symfony Kernel *(this is the fastest browser)*.
+1. [KernelBrowser](#kernelbrowser): makes requests using your Symfony Kernel, like [the Symfony BrowserKit component](https://symfony.com/doc/current/components/browser_kit.html)
+   *(this is the fastest browser)*.
 2. [HttpBrowser](#httpbrowser): makes requests to a webserver using `symfony/http-client`.
 3. [PantherBrowser](#pantherbrowser): makes requests to a webserver with a real browser using `symfony/panther` which
    allows testing javascript *(this is the slowest browser)*.
 
-You can use these Browsers in your tests by having your test class use the `HasBrowser` trait:
+You can use these Browsers in your tests using traits:
 
 ```php
 namespace App\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Browser\Test\HasBrowser;
+use Zenstruck\Browser\Test\HasHttpBrowser;
+use Zenstruck\Browser\Test\HasPantherBrowser;
 
 class MyTest extends TestCase
 {
+    // provides a browser() method that returns the KernelBrowser
     use HasBrowser;
+    // provides httpBrowser()
+    use HasHttpBrowser;
+    // provides pantherBrowser()
+    use HasPantherBrowser;
 
     /**
      * Requires this test extend either Symfony\Bundle\FrameworkBundle\Test\KernelTestCase
@@ -114,7 +122,7 @@ class MyTest extends TestCase
      */
     public function test_using_kernel_browser(): void
     {
-        $this->kernelBrowser()
+        $this->browser()
             ->visit('/my/page')
             ->assertSuccessful()
         ;

--- a/src/Browser/Test/HasBrowser.php
+++ b/src/Browser/Test/HasBrowser.php
@@ -4,116 +4,14 @@ namespace Zenstruck\Browser\Test;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\BrowserKit\HttpBrowser as HttpBrowserClient;
-use Symfony\Component\Panther\Client as PantherClient;
-use Symfony\Component\Panther\PantherTestCase;
-use Zenstruck\Browser\HttpBrowser;
 use Zenstruck\Browser\KernelBrowser;
-use Zenstruck\Browser\PantherBrowser;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 trait HasBrowser
 {
-    /** @var HttpBrowserClient[] */
-    private static array $httpBrowserClients = [];
-    private static ?PantherClient $primaryPantherClient = null;
-
-    /**
-     * @internal
-     * @after
-     */
-    final public static function _resetBrowserClients(): void
-    {
-        self::$httpBrowserClients = [];
-        self::$primaryPantherClient = null;
-    }
-
-    protected function pantherBrowser(array $options = [], array $kernelOptions = [], array $managerOptions = []): PantherBrowser
-    {
-        $class = $_SERVER['PANTHER_BROWSER_CLASS'] ?? PantherBrowser::class;
-
-        if (!\is_a($class, PantherBrowser::class, true)) {
-            throw new \RuntimeException(\sprintf('"PANTHER_BROWSER_CLASS" env variable must reference a class that extends %s.', PantherBrowser::class));
-        }
-
-        if (self::$primaryPantherClient) {
-            $browser = new $class(static::createAdditionalPantherClient());
-        } else {
-            self::$primaryPantherClient = static::createPantherClient(
-                \array_merge(['browser' => $_SERVER['PANTHER_BROWSER'] ?? static::CHROME], $options),
-                $kernelOptions,
-                $managerOptions
-            );
-
-            $browser = new $class(self::$primaryPantherClient);
-        }
-
-        BrowserExtension::registerBrowser($browser);
-
-        return $browser
-            ->setSourceDir($_SERVER['BROWSER_SOURCE_DIR'] ?? './var/browser/source')
-            ->setScreenshotDir($_SERVER['BROWSER_SCREENSHOT_DIR'] ?? './var/browser/screenshots')
-            ->setConsoleLogDir($_SERVER['BROWSER_CONSOLE_LOG_DIR'] ?? './var/browser/console-logs')
-        ;
-    }
-
-    protected function httpBrowser(array $kernelOptions = [], array $pantherOptions = []): HttpBrowser
-    {
-        $class = $_SERVER['HTTP_BROWSER_CLASS'] ?? HttpBrowser::class;
-
-        if (!\is_a($class, HttpBrowser::class, true)) {
-            throw new \RuntimeException(\sprintf('"HTTP_BROWSER_CLASS" env variable must reference a class that extends %s.', HttpBrowser::class));
-        }
-
-        $baseUri = $_SERVER['HTTP_BROWSER_URI'] ?? null;
-
-        if (!$baseUri && !$this instanceof PantherTestCase) {
-            throw new \RuntimeException(\sprintf('If not using "HTTP_BROWSER_URI", your TestCase must extend "%s".', PantherTestCase::class));
-        }
-
-        if (!$baseUri) {
-            self::startWebServer($pantherOptions);
-
-            $baseUri = self::$baseUri;
-        }
-
-        // copied from PantherTestCaseTrait::createHttpBrowserClient()
-        $client = new HttpBrowserClient();
-        $urlComponents = \parse_url($baseUri);
-        $host = $urlComponents['host'];
-
-        if (isset($urlComponents['port'])) {
-            $host .= ":{$urlComponents['port']}";
-        }
-
-        $client->setServerParameter('HTTP_HOST', $host);
-
-        if ('https' === ($urlComponents['scheme'] ?? 'http')) {
-            $client->setServerParameter('HTTPS', 'true');
-        }
-
-        $browser = new $class(self::$httpBrowserClients[] = $client);
-
-        if ($this instanceof KernelTestCase) {
-            if (!static::$booted) {
-                static::bootKernel($kernelOptions);
-            }
-
-            if (static::$container->has('profiler')) {
-                $browser->setProfiler(static::$container->get('profiler'));
-            }
-        }
-
-        BrowserExtension::registerBrowser($browser);
-
-        return $browser
-            ->setSourceDir($_SERVER['BROWSER_SOURCE_DIR'] ?? './var/browser/source')
-        ;
-    }
-
-    protected function kernelBrowser(array $options = []): KernelBrowser
+    public function browser(array $options = []): KernelBrowser
     {
         if (!$this instanceof KernelTestCase) {
             throw new \RuntimeException(\sprintf('The "%s" method can only be used on TestCases that extend "%s".', __METHOD__, KernelTestCase::class));

--- a/src/Browser/Test/HasHttpBrowser.php
+++ b/src/Browser/Test/HasHttpBrowser.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Zenstruck\Browser\Test;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\BrowserKit\HttpBrowser as HttpBrowserClient;
+use Symfony\Component\Panther\PantherTestCase;
+use Zenstruck\Browser\HttpBrowser;
+
+trait HasHttpBrowser
+{
+    /** @var HttpBrowserClient[] */
+    private static array $httpBrowserClients = [];
+
+    /**
+     * @internal
+     * @after
+     */
+    final public static function _resetHttpBrowserClients(): void
+    {
+        self::$httpBrowserClients = [];
+    }
+
+    protected function httpBrowser(array $kernelOptions = [], array $pantherOptions = []): HttpBrowser
+    {
+        $class = $_SERVER['HTTP_BROWSER_CLASS'] ?? HttpBrowser::class;
+
+        if (!\is_a($class, HttpBrowser::class, true)) {
+            throw new \RuntimeException(\sprintf('"HTTP_BROWSER_CLASS" env variable must reference a class that extends %s.', HttpBrowser::class));
+        }
+
+        $baseUri = $_SERVER['HTTP_BROWSER_URI'] ?? null;
+
+        if (!$baseUri && !$this instanceof PantherTestCase) {
+            throw new \RuntimeException(\sprintf('If not using "HTTP_BROWSER_URI", your TestCase must extend "%s".', PantherTestCase::class));
+        }
+
+        if (!$baseUri) {
+            self::startWebServer($pantherOptions);
+
+            $baseUri = self::$baseUri;
+        }
+
+        // copied from PantherTestCaseTrait::createHttpBrowserClient()
+        $client = new HttpBrowserClient();
+        $urlComponents = \parse_url($baseUri);
+        $host = $urlComponents['host'];
+
+        if (isset($urlComponents['port'])) {
+            $host .= ":{$urlComponents['port']}";
+        }
+
+        $client->setServerParameter('HTTP_HOST', $host);
+
+        if ('https' === ($urlComponents['scheme'] ?? 'http')) {
+            $client->setServerParameter('HTTPS', 'true');
+        }
+
+        $browser = new $class(self::$httpBrowserClients[] = $client);
+
+        if ($this instanceof KernelTestCase) {
+            if (!static::$booted) {
+                static::bootKernel($kernelOptions);
+            }
+
+            if (static::$container->has('profiler')) {
+                $browser->setProfiler(static::$container->get('profiler'));
+            }
+        }
+
+        BrowserExtension::registerBrowser($browser);
+
+        return $browser
+            ->setSourceDir($_SERVER['BROWSER_SOURCE_DIR'] ?? './var/browser/source')
+        ;
+    }
+}

--- a/src/Browser/Test/HasPantherBrowser.php
+++ b/src/Browser/Test/HasPantherBrowser.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Zenstruck\Browser\Test;
+
+use Symfony\Component\Panther\Client as PantherClient;
+use Symfony\Component\Panther\PantherTestCase;
+use Zenstruck\Browser\PantherBrowser;
+
+trait HasPantherBrowser
+{
+    private static ?PantherClient $primaryPantherClient = null;
+
+    /**
+     * @internal
+     * @after
+     */
+    final public static function _resetPantherBrowserClient(): void
+    {
+        self::$primaryPantherClient = null;
+    }
+
+    protected function pantherBrowser(array $options = [], array $kernelOptions = [], array $managerOptions = []): PantherBrowser
+    {
+        $class = $_SERVER['PANTHER_BROWSER_CLASS'] ?? PantherBrowser::class;
+
+        if (!$this instanceof PantherTestCase) {
+            throw new \RuntimeException(\sprintf('The "%s" method can only be used on TestCases that extend "%s".', __METHOD__, PantherTestCase::class));
+        }
+
+        if (!\is_a($class, PantherBrowser::class, true)) {
+            throw new \RuntimeException(\sprintf('"PANTHER_BROWSER_CLASS" env variable must reference a class that extends %s.', PantherBrowser::class));
+        }
+
+        if (self::$primaryPantherClient) {
+            $browser = new $class(static::createAdditionalPantherClient());
+        } else {
+            self::$primaryPantherClient = static::createPantherClient(
+                \array_merge(['browser' => $_SERVER['PANTHER_BROWSER'] ?? static::CHROME], $options),
+                $kernelOptions,
+                $managerOptions
+            );
+
+            $browser = new $class(self::$primaryPantherClient);
+        }
+
+        BrowserExtension::registerBrowser($browser);
+
+        return $browser
+            ->setSourceDir($_SERVER['BROWSER_SOURCE_DIR'] ?? './var/browser/source')
+            ->setScreenshotDir($_SERVER['BROWSER_SCREENSHOT_DIR'] ?? './var/browser/screenshots')
+            ->setConsoleLogDir($_SERVER['BROWSER_CONSOLE_LOG_DIR'] ?? './var/browser/console-logs')
+        ;
+    }
+}

--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -5,7 +5,6 @@ namespace Zenstruck\Browser\Tests;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\VarDumper\VarDumper;
 use Zenstruck\Browser;
-use Zenstruck\Browser\Test\HasBrowser;
 use Zenstruck\Browser\Tests\Fixture\TestComponent1;
 use Zenstruck\Browser\Tests\Fixture\TestComponent2;
 use Zenstruck\Callback\Exception\UnresolveableArgument;
@@ -15,8 +14,6 @@ use Zenstruck\Callback\Exception\UnresolveableArgument;
  */
 trait BrowserTests
 {
-    use HasBrowser;
-
     /**
      * @test
      */

--- a/tests/ConfigureBrowserTest.php
+++ b/tests/ConfigureBrowserTest.php
@@ -11,20 +11,18 @@ use Zenstruck\Browser\Test\HasBrowser;
  */
 final class ConfigureBrowserTest extends WebTestCase
 {
-    use HasBrowser {
-        kernelBrowser as baseKernelBrowser;
-    }
+    use HasBrowser;
 
     /**
      * @test
      */
     public function browser_has_been_configured(): void
     {
-        $this->kernelBrowser()->assertOn('/page1');
+        $this->page1Browser()->assertOn('/page1');
     }
 
-    protected function kernelBrowser(): KernelBrowser
+    public function page1Browser(): KernelBrowser
     {
-        return $this->baseKernelBrowser()->visit('/page1');
+        return $this->browser()->visit('/page1');
     }
 }

--- a/tests/HttpBrowserTest.php
+++ b/tests/HttpBrowserTest.php
@@ -4,13 +4,14 @@ namespace Zenstruck\Browser\Tests;
 
 use Symfony\Component\Panther\PantherTestCase;
 use Zenstruck\Browser\HttpBrowser;
+use Zenstruck\Browser\Test\HasHttpBrowser;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 final class HttpBrowserTest extends PantherTestCase
 {
-    use BrowserKitBrowserTests;
+    use BrowserKitBrowserTests, HasHttpBrowser;
 
     /**
      * @test

--- a/tests/KernelBrowserTests.php
+++ b/tests/KernelBrowserTests.php
@@ -5,13 +5,14 @@ namespace Zenstruck\Browser\Tests;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser as SymfonyKernelBrowser;
 use Symfony\Component\Security\Core\User\User;
 use Zenstruck\Browser\KernelBrowser;
+use Zenstruck\Browser\Test\HasBrowser;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 trait KernelBrowserTests
 {
-    use BrowserKitBrowserTests;
+    use BrowserKitBrowserTests, HasBrowser;
 
     /**
      * @test
@@ -91,10 +92,5 @@ trait KernelBrowserTests
         ;
 
         $this->assertTrue($profile->hasCollector('request'));
-    }
-
-    protected function browser(): KernelBrowser
-    {
-        return $this->kernelBrowser();
     }
 }

--- a/tests/NonPantherHttpBrowserTest.php
+++ b/tests/NonPantherHttpBrowserTest.php
@@ -4,13 +4,14 @@ namespace Zenstruck\Browser\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Zenstruck\Browser\Test\HasBrowser;
+use Zenstruck\Browser\Test\HasHttpBrowser;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
 final class NonPantherHttpBrowserTest extends TestCase
 {
-    use HasBrowser;
+    use HasBrowser, HasHttpBrowser;
 
     protected function setUp(): void
     {

--- a/tests/PantherBrowserTest.php
+++ b/tests/PantherBrowserTest.php
@@ -5,6 +5,7 @@ namespace Zenstruck\Browser\Tests;
 use PHPUnit\Framework\AssertionFailedError;
 use Symfony\Component\Panther\PantherTestCase;
 use Zenstruck\Browser\PantherBrowser;
+use Zenstruck\Browser\Test\HasPantherBrowser;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -13,7 +14,7 @@ use Zenstruck\Browser\PantherBrowser;
  */
 final class PantherBrowserTest extends PantherTestCase
 {
-    use BrowserTests;
+    use BrowserTests, HasPantherBrowser;
 
     /**
      * @test


### PR DESCRIPTION
This partially reverts #3, while keeping the API introduced there.

With this change, `HasBrowser` is still available with the same API as before. Yet, all browsers are also available in their own trait.

I'm not sure if you want this amount of trait hacking in the library. I'm experimenting with using Browser in [Pest](https://pestphp.com/). Having a trait for each browser implementation is the best way to configure the browser implementation in Pest. 