### PR TITLE
Make Browser abstract, add Browser::cookies()

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ $browser
     ->dd('foo') // if json response, array key
     ->dd('foo.*.baz') // if json response, JMESPath notation can be used
 ;
+
+// access "cookies"
+$browser->cookies(); // Symfony\Component\BrowserKit\CookieJar
 ```
 
 ### KernelBrowser/HttpBrowser

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -10,6 +10,7 @@ use Behat\Mink\Mink;
 use Behat\Mink\Session;
 use Behat\Mink\WebAssert;
 use PHPUnit\Framework\Assert as PHPUnit;
+use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\Filesystem\Filesystem;
 use Zenstruck\Browser\Component;
 use Zenstruck\Browser\Response;
@@ -398,6 +399,8 @@ abstract class Browser
             fn() => $this->webAssert()->elementAttributeNotContains('css', $selector, $attribute, $expected)
         );
     }
+
+    abstract public function cookies(): CookieJar;
 
     /**
      * @internal

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -19,7 +19,7 @@ use Zenstruck\Callback\Parameter;
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
  */
-class Browser
+abstract class Browser
 {
     private const SESSION = 'app';
 

--- a/src/Browser/BrowserKitBrowser.php
+++ b/src/Browser/BrowserKitBrowser.php
@@ -4,6 +4,7 @@ namespace Zenstruck\Browser;
 
 use PHPUnit\Framework\Assert as PHPUnit;
 use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use Zenstruck\Browser;
 use Zenstruck\Browser\Mink\BrowserKitDriver;
@@ -227,6 +228,11 @@ abstract class BrowserKitBrowser extends Browser
         PHPUnit::assertSame($expected, $this->response()->search($expression));
 
         return $this;
+    }
+
+    public function cookies(): CookieJar
+    {
+        return $this->inner->getCookieJar();
     }
 
     abstract public function profile(): Profile;

--- a/src/Browser/PantherBrowser.php
+++ b/src/Browser/PantherBrowser.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Browser;
 
 use PHPUnit\Framework\Assert as PHPUnit;
+use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Panther\Client;
 use Symfony\Component\VarDumper\VarDumper;
@@ -208,6 +209,11 @@ class PantherBrowser extends Browser
         echo \sprintf("\n\nScreenshot saved as \"%s\".\n\n", \end($this->savedScreenshots));
 
         $this->die();
+    }
+
+    public function cookies(): CookieJar
+    {
+        return $this->client->getCookieJar();
     }
 
     /**

--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -401,6 +401,16 @@ trait BrowserTests
         $this->assertSame('list 2', $output[1]);
     }
 
+    /**
+     * @test
+     */
+    public function can_access_cookies(): void
+    {
+        $cookies = $this->browser()->visit('/page1')->cookies();
+
+        $this->assertIsArray($cookies->all());
+    }
+
     protected static function catchFileContents(string $expectedFile, callable $callback): string
     {
         (new Filesystem())->remove($expectedFile);


### PR DESCRIPTION
This solidifies that this lib is a wrapper around `BrowserKit`/`AbstractBrowser` and not Mink.