### PR TITLE
Fix HttpOptions query/parameters

### DIFF
--- a/src/Browser/BrowserKitBrowser.php
+++ b/src/Browser/BrowserKitBrowser.php
@@ -104,7 +104,14 @@ abstract class BrowserKitBrowser extends Browser
 
         $options = HttpOptions::create($options);
 
-        $this->inner->request($method, $url, $options->query(), $options->files(), $options->server(), $options->body());
+        $this->inner->request(
+            $method,
+            $options->addQueryToUrl($url),
+            $options->parameters(),
+            $options->files(),
+            $options->server(),
+            $options->body()
+        );
 
         return $this;
     }

--- a/tests/BrowserKitBrowserTests.php
+++ b/tests/BrowserKitBrowserTests.php
@@ -206,6 +206,14 @@ trait BrowserKitBrowserTests
             ->assertContains('"x-token":["my-token"]')
             ->post('/http-method', HttpOptions::json()->withHeader('content-type', 'application/ld+json'))
             ->assertContains('"content-type":["application\/ld+json"]')
+            ->post('/http-method?q1=qv1')
+            ->assertContains('"query":{"q1":"qv1"}')
+            ->post('/http-method', ['query' => ['q1' => 'qv1']])
+            ->assertContains('"query":{"q1":"qv1"}')
+            ->post('/http-method?q1=qv1', ['query' => ['q2' => 'qv2']])
+            ->assertContains('"query":{"q1":"qv1","q2":"qv2"}')
+            ->post('/http-method', ['body' => ['b1' => 'bv1']])
+            ->assertContains('"request":{"b1":"bv1"}')
         ;
     }
 

--- a/tests/Fixture/Kernel.php
+++ b/tests/Fixture/Kernel.php
@@ -67,7 +67,7 @@ final class Kernel extends BaseKernel
             'attributes' => $request->attributes->all(),
             'files' => $request->files->all(),
             'server' => $request->server->all(),
-            'request' => $request->query->all(),
+            'request' => $request->request->all(),
             'content' => $request->getContent(),
             'ajax' => $request->isXmlHttpRequest(),
         ]);

--- a/tests/HttpOptionsTest.php
+++ b/tests/HttpOptionsTest.php
@@ -17,7 +17,7 @@ final class HttpOptionsTest extends TestCase
     {
         $options = new HttpOptions();
 
-        $this->assertEmpty($options->query());
+        $this->assertSame('/', $options->addQueryToUrl('/'));
         $this->assertEmpty($options->files());
         $this->assertEmpty($options->server());
         $this->assertNull($options->body());
@@ -30,7 +30,7 @@ final class HttpOptionsTest extends TestCase
     {
         $options = new HttpOptions([
             'headers' => ['header' => 'header value'],
-            'query' => $expectedQuery = ['param' => 'param value'],
+            'query' => ['param' => 'param value'],
             'files' => $expectedFiles = ['file' => 'file value'],
             'server' => ['server' => 'server value'],
             'body' => $expectedBody = 'body value',
@@ -38,7 +38,7 @@ final class HttpOptionsTest extends TestCase
             'ajax' => false,
         ]);
 
-        $this->assertSame($expectedQuery, $options->query());
+        $this->assertSame('/?param=param+value', $options->addQueryToUrl('/'));
         $this->assertSame($expectedFiles, $options->files());
         $this->assertSame(['server' => 'server value', 'HTTP_HEADER' => 'header value'], $options->server());
         $this->assertSame($expectedBody, $options->body());
@@ -55,10 +55,10 @@ final class HttpOptionsTest extends TestCase
             ->withHeader('header2', 'header2 value')
             ->withFiles($expectedFiles = ['file' => 'file value'])
             ->withServer(['server' => 'server value'])
-            ->withQuery($expectedQuery = ['param' => 'param value'])
+            ->withQuery(['param' => 'param value'])
         ;
 
-        $this->assertSame($expectedQuery, $options->query());
+        $this->assertSame('/?param=param+value', $options->addQueryToUrl('/'));
         $this->assertSame($expectedFiles, $options->files());
         $this->assertSame($expectedBody, $options->body());
         $this->assertSame(
@@ -199,7 +199,7 @@ final class HttpOptionsTest extends TestCase
     {
         $options = HttpOptions::create([
             'headers' => ['header1' => 'header1 value'],
-            'query' => $expectedQuery = ['param' => 'param value'],
+            'query' => ['param' => 'param value'],
             'files' => $expectedFiles = ['file' => 'file value'],
             'server' => ['server' => 'server value'],
             'body' => null,
@@ -211,7 +211,7 @@ final class HttpOptionsTest extends TestCase
             'json' => $json = ['json' => 'body'],
         ]);
 
-        $this->assertSame($expectedQuery, $options->query());
+        $this->assertSame('/?param=param+value', $options->addQueryToUrl('/'));
         $this->assertSame($expectedFiles, $options->files());
         $this->assertSame(\json_encode($json), $options->body());
         $this->assertSame(
@@ -234,7 +234,7 @@ final class HttpOptionsTest extends TestCase
     {
         $options = HttpOptions::create([
             'headers' => ['header1' => 'header1 value'],
-            'query' => $expectedQuery = ['param' => 'param value'],
+            'query' => ['param' => 'param value'],
             'files' => $expectedFiles = ['file' => 'file value'],
             'server' => ['server' => 'server value'],
             'body' => null,
@@ -243,7 +243,7 @@ final class HttpOptionsTest extends TestCase
         ]);
         $options = $options->merge(new class(['headers' => ['header2' => 'header2 value']]) extends HttpOptions {});
 
-        $this->assertSame($expectedQuery, $options->query());
+        $this->assertSame('/?param=param+value', $options->addQueryToUrl('/'));
         $this->assertSame($expectedFiles, $options->files());
         $this->assertNull($options->body());
         $this->assertSame(


### PR DESCRIPTION
Fixed an bug where the _query_ was used as the request _parameters_. The query is now properly added as a query string to the url.

Now, to add request parameters, set the _body_ to an array. It is possible to add the query via the request URL, the query option or a combination of both.