### PR TITLE
Allow `Browser::click()` to work with css selector

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -260,6 +260,8 @@ class Browser
     }
 
     /**
+     * Click on a button, link or any DOM element.
+     *
      * @return static
      */
     final public function click(string $selector): self
@@ -268,18 +270,12 @@ class Browser
             $this->documentElement()->pressButton($selector);
         } catch (ElementNotFoundException $e) {
             // try link
-            $this->documentElement()->clickLink($selector);
+            try {
+                $this->documentElement()->clickLink($selector);
+            } catch (ElementNotFoundException $e) {
+                $this->documentElement()->find('css', $selector)->click();
+            }
         }
-
-        return $this;
-    }
-
-    /**
-     * @param string $selector Any CSS selector is valid
-     */
-    public function clickOnElement(string $selector): self
-    {
-        $this->documentElement()->find('css', $selector)->click();
 
         return $this;
     }

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -277,6 +277,16 @@ class Browser
     /**
      * @return static
      */
+    public function clickOnElement(string $selector): self
+    {
+        $this->documentElement()->findById($selector)->click();
+
+        return $this;
+    }
+
+    /**
+     * @return static
+     */
     final public function assertSee(string $expected): self
     {
         return $this->wrapMinkExpectation(

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -275,11 +275,11 @@ class Browser
     }
 
     /**
-     * @return static
+     * @param string $selector Any CSS selector is valid
      */
     public function clickOnElement(string $selector): self
     {
-        $this->documentElement()->findById($selector)->click();
+        $this->documentElement()->find('css', $selector)->click();
 
         return $this;
     }

--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -339,6 +339,18 @@ trait BrowserTests
     /**
      * @test
      */
+    public function click_on_element(): void
+    {
+        $this->browser()
+            ->visit('/page1')
+            ->clickOnElement('#link a')
+            ->assertOn('/page2')
+        ;
+    }
+
+    /**
+     * @test
+     */
     public function form_actions_by_field_label(): void
     {
         $this->browser()

--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -343,7 +343,7 @@ trait BrowserTests
     {
         $this->browser()
             ->visit('/page1')
-            ->clickOnElement('#link a')
+            ->click('#link a')
             ->assertOn('/page2')
         ;
     }


### PR DESCRIPTION
I want to be able to click on anything. We have some weird javascript that hide away a checkbox...

This only support selecting an element by ID. I am not sure how to implement it better. 