### PR TITLE
Normalized test name matches int and string indexed data provider

### DIFF
--- a/src/Browser/Test/BrowserExtension.php
+++ b/src/Browser/Test/BrowserExtension.php
@@ -108,12 +108,15 @@ final class BrowserExtension implements BeforeFirstTestHook, BeforeTestHook, Aft
 
     private static function normalizeTestName(string $name): string
     {
-        \preg_match('#^([\w:\\\]+)(.+\#(\d+).+)?$#', $name, $matches);
+        // Try to match for a numeric data set index. If it didn't, match for a string one.
+        if (!\preg_match('#^([\w:\\\]+)(.+\#(\d+).+)?$#', $name, $matches)) {
+            \preg_match('#^([\w:\\\]+)(.+"([\w ]+)".+)?$#', $name, $matches);
+        }
 
         $normalized = \strtr($matches[1], '\\:', '-_');
 
         if (isset($matches[3])) {
-            $normalized .= '__data-set-'.$matches[3];
+            $normalized .= '__data-set-'.strtr($matches[3], '\\: ', '-_-');
         }
 
         return $normalized;

--- a/src/Browser/Test/BrowserExtension.php
+++ b/src/Browser/Test/BrowserExtension.php
@@ -116,7 +116,7 @@ final class BrowserExtension implements BeforeFirstTestHook, BeforeTestHook, Aft
         $normalized = \strtr($matches[1], '\\:', '-_');
 
         if (isset($matches[3])) {
-            $normalized .= '__data-set-'.strtr($matches[3], '\\: ', '-_-');
+            $normalized .= '__data-set-'.\strtr($matches[3], '\\: ', '-_-');
         }
 
         return $normalized;


### PR DESCRIPTION
An simple attempt to fix #67 

Tell me if I can improve something.

I tried to keep the regexes simple. It could be merged into one but the `$matches` array index handling would be harder depending on the case.