### PR TITLE
Expect exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,13 @@ $browser
     // combination of assertRedirected(), followRedirect(), assertOn()
     ->assertRedirectedTo('/some/page') // follows all redirects by default
     ->assertRedirectedTo('/some/page', 1) // just follow 1 redirect
+
+    // exception assertions for the "next request"
+    ->expectException(MyException::class, 'the message')
+    ->post('/url/that/throws/exception') // fails if above exception not thrown
+
+    ->expectException(MyException::class, 'the message')
+    ->click('link or button') // fails if above exception not thrown
 ;
 
 // Access the Symfony Profiler for the last request

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -44,7 +44,7 @@ abstract class Browser
      */
     final public function visit(string $uri): self
     {
-        $this->session()->visit($uri);
+        $this->session()->request('GET', $uri);
 
         return $this;
     }

--- a/src/Browser/KernelBrowser.php
+++ b/src/Browser/KernelBrowser.php
@@ -81,6 +81,24 @@ class KernelBrowser extends Browser
     }
 
     /**
+     * Expect the next request to throw this exception. Fails if not thrown.
+     *
+     * @param class-string|callable $expectedException string: class name of the expected exception
+     *                                                 callable: uses the first argument's type-hint
+     *                                                 to determine the expected exception class. When
+     *                                                 exception is caught, callable is invoked with
+     *                                                 the caught exception
+     * @param string|null           $expectedMessage   Assert the caught exception message "contains"
+     *                                                 this string
+     */
+    public function expectException($expectedException, ?string $expectedMessage = null): self
+    {
+        $this->session()->expectException($expectedException, $expectedMessage);
+
+        return $this;
+    }
+
+    /**
      * Enable profiling for the next request. Not required if profiling is
      * globally enabled.
      *

--- a/src/Browser/KernelBrowser.php
+++ b/src/Browser/KernelBrowser.php
@@ -205,14 +205,7 @@ class KernelBrowser extends Browser
 
         $options = HttpOptions::create($options);
 
-        $this->client()->request(
-            $method,
-            $options->addQueryToUrl($url),
-            $options->parameters(),
-            $options->files(),
-            $options->server(),
-            $options->body()
-        );
+        $this->session()->request($method, $options->addQueryToUrl($url), $options);
 
         return $this;
     }

--- a/src/Browser/Session.php
+++ b/src/Browser/Session.php
@@ -62,6 +62,15 @@ final class Session extends MinkSession
         throw new DriverException('This is not a JSON response.');
     }
 
+    public function request(string $method, string $url, ?HttpOptions $options = null): void
+    {
+        if (!$this->isStarted()) {
+            $this->start();
+        }
+
+        $this->getDriver()->request(\mb_strtoupper($method), $url, $options ?? new HttpOptions());
+    }
+
     public function source(): string
     {
         try {

--- a/src/Browser/Session.php
+++ b/src/Browser/Session.php
@@ -71,6 +71,14 @@ final class Session extends MinkSession
         $this->getDriver()->request(\mb_strtoupper($method), $url, $options ?? new HttpOptions());
     }
 
+    /**
+     * @param class-string|callable $expectedException
+     */
+    public function expectException($expectedException, ?string $expectedMessage = null): void
+    {
+        $this->getDriver()->expectException($expectedException, $expectedMessage);
+    }
+
     public function source(): string
     {
         try {

--- a/src/Browser/Session/Driver.php
+++ b/src/Browser/Session/Driver.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Browser\Session;
 
 use Behat\Mink\Driver\CoreDriver;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Zenstruck\Browser\HttpOptions;
 
@@ -48,6 +49,14 @@ abstract class Driver extends CoreDriver
 
     public function quit(): void
     {
+    }
+
+    /**
+     * @param class-string|callable $expectedException
+     */
+    public function expectException($expectedException, ?string $expectedMessage = null): void
+    {
+        throw new UnsupportedDriverActionException('%s does not support expecting exceptions.', $this);
     }
 
     abstract public function request(string $method, string $url, HttpOptions $options): void;

--- a/src/Browser/Session/Driver.php
+++ b/src/Browser/Session/Driver.php
@@ -4,6 +4,7 @@ namespace Zenstruck\Browser\Session;
 
 use Behat\Mink\Driver\CoreDriver;
 use Symfony\Component\BrowserKit\AbstractBrowser;
+use Zenstruck\Browser\HttpOptions;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -48,4 +49,6 @@ abstract class Driver extends CoreDriver
     public function quit(): void
     {
     }
+
+    abstract public function request(string $method, string $url, HttpOptions $options): void;
 }

--- a/src/Browser/Session/Driver/BrowserKitDriver.php
+++ b/src/Browser/Session/Driver/BrowserKitDriver.php
@@ -12,6 +12,7 @@ namespace Zenstruck\Browser\Session\Driver;
 
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\Exception\BadMethodCallException;
@@ -23,6 +24,7 @@ use Symfony\Component\DomCrawler\Field\FormField;
 use Symfony\Component\DomCrawler\Field\InputFormField;
 use Symfony\Component\DomCrawler\Field\TextareaFormField;
 use Symfony\Component\DomCrawler\Form;
+use Zenstruck\Assert;
 use Zenstruck\Browser\HttpOptions;
 use Zenstruck\Browser\Session\Driver;
 
@@ -45,11 +47,21 @@ final class BrowserKitDriver extends Driver
     /** @var array<string,string> */
     private array $serverParameters = [];
 
+    /** @var mixed */
+    private $expectedException;
+    private ?string $expectedExceptionMessage = null;
+
     public function __construct(AbstractBrowser $client)
     {
         $client->followRedirects(true);
 
         parent::__construct($client);
+    }
+
+    public function expectException($expectedException, ?string $expectedMessage = null): void
+    {
+        $this->expectedException = $expectedException;
+        $this->expectedExceptionMessage = $expectedMessage;
     }
 
     public function stop(): void
@@ -71,14 +83,16 @@ final class BrowserKitDriver extends Driver
     {
         $options = $options->merge(['server' => $this->serverParameters]);
 
-        $this->client()->request(
-            $method,
-            $options->addQueryToUrl($url),
-            $options->parameters(),
-            $options->files(),
-            $options->server(),
-            $options->body()
-        );
+        $this->wrapRequest(function() use ($method, $url, $options) {
+            $this->client()->request(
+                $method,
+                $options->addQueryToUrl($url),
+                $options->parameters(),
+                $options->files(),
+                $options->server(),
+                $options->body()
+            );
+        });
     }
 
     public function getCurrentUrl(): string
@@ -308,7 +322,7 @@ final class BrowserKitDriver extends Driver
         $tagName = $node->nodeName;
 
         if ('a' === $tagName) {
-            $this->client()->click($crawler->link());
+            $this->wrapRequest(fn() => $this->client()->click($crawler->link()));
             $this->forms = [];
         } elseif ($this->canSubmitForm($node)) {
             $this->submit($crawler->form());
@@ -562,7 +576,7 @@ final class BrowserKitDriver extends Driver
             }
         }
 
-        $this->client()->submit($form, [], $this->serverParameters);
+        $this->wrapRequest(fn() => $this->client()->submit($form, [], $this->serverParameters));
 
         $this->forms = [];
     }
@@ -693,5 +707,25 @@ final class BrowserKitDriver extends Driver
         }
 
         return $cached;
+    }
+
+    private function wrapRequest(callable $callback): void
+    {
+        if (!$this->expectedException) {
+            $callback();
+
+            return;
+        }
+
+        $client = $this->client();
+
+        \assert($client instanceof KernelBrowser);
+
+        // todo reset to original value after request
+        $client->catchExceptions(false);
+
+        Assert::that($callback)->throws($this->expectedException, $this->expectedExceptionMessage);
+
+        $this->expectedException = $this->expectedExceptionMessage = null;
     }
 }

--- a/src/Browser/Session/Driver/BrowserKitDriver.php
+++ b/src/Browser/Session/Driver/BrowserKitDriver.php
@@ -23,6 +23,7 @@ use Symfony\Component\DomCrawler\Field\FormField;
 use Symfony\Component\DomCrawler\Field\InputFormField;
 use Symfony\Component\DomCrawler\Field\TextareaFormField;
 use Symfony\Component\DomCrawler\Form;
+use Zenstruck\Browser\HttpOptions;
 use Zenstruck\Browser\Session\Driver;
 
 /**
@@ -66,10 +67,18 @@ final class BrowserKitDriver extends Driver
         $this->serverParameters = [];
     }
 
-    public function visit($url): void
+    public function request(string $method, string $url, HttpOptions $options): void
     {
-        $this->client()->request('GET', $url, [], [], $this->serverParameters);
-        $this->forms = [];
+        $options = $options->merge(['server' => $this->serverParameters]);
+
+        $this->client()->request(
+            $method,
+            $options->addQueryToUrl($url),
+            $options->parameters(),
+            $options->files(),
+            $options->server(),
+            $options->body()
+        );
     }
 
     public function getCurrentUrl(): string

--- a/src/Browser/Session/Driver/PantherDriver.php
+++ b/src/Browser/Session/Driver/PantherDriver.php
@@ -3,6 +3,7 @@
 namespace Zenstruck\Browser\Session\Driver;
 
 use Behat\Mink\Exception\DriverException;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Facebook\WebDriver\Exception\NoSuchElementException;
 use Facebook\WebDriver\Interactions\Internal\WebDriverCoordinates;
 use Facebook\WebDriver\Internal\WebDriverLocatable;
@@ -16,6 +17,7 @@ use Symfony\Component\Panther\DomCrawler\Field\ChoiceFormField;
 use Symfony\Component\Panther\DomCrawler\Field\FileFormField;
 use Symfony\Component\Panther\DomCrawler\Field\InputFormField;
 use Symfony\Component\Panther\DomCrawler\Field\TextareaFormField;
+use Zenstruck\Browser\HttpOptions;
 use Zenstruck\Browser\Session\Driver;
 
 /**
@@ -35,8 +37,12 @@ final class PantherDriver extends Driver
         parent::__construct($client);
     }
 
-    public function visit($url): void
+    public function request(string $method, string $url, HttpOptions $options): void
     {
+        if ('GET' !== $method) {
+            throw new UnsupportedDriverActionException('%s only supports "GET" requests.', $this);
+        }
+
         $this->client()->request('GET', $this->prepareUrl($url));
     }
 

--- a/tests/Fixture/Kernel.php
+++ b/tests/Fixture/Kernel.php
@@ -68,6 +68,10 @@ final class Kernel extends BaseKernel
             $request->files->all()
         );
 
+        if ('e' === $request->request->get('submit_1')) {
+            throw new \RuntimeException('fail!');
+        }
+
         return new JsonResponse(\array_merge(
             $request->request->all(),
             \array_filter($files)

--- a/tests/Fixture/files/page1.html
+++ b/tests/Fixture/files/page1.html
@@ -8,6 +8,7 @@
 <body>
     <h1>h1 title</h1>
     <p id="link"><a href="/page2">a link</a> not a link</p>
+    <p><a href="/exception">exception link</a></p>
     <ul>
         <li>list 1</li>
         <li>list 2</li>
@@ -59,6 +60,7 @@
         <button type="submit" name="submit_1" value="b">Submit B</button>
         <button type="submit" name="submit_2" value="c">Submit C</button>
         <button name="submit_2" value="d">Submit D</button>
+        <button name="submit_1" value="e">Submit Exception</button>
     </form>
 </body>
 </html>


### PR DESCRIPTION
Closes #46.

```php
$browser
    ->expectException(SomeException::class) // auto-enables ->throwExceptions() for the next request
    ->post('/some/url') // fail if SomeException wasn't thrown

    ->expectException(SomeException::class, 'expected exception message')
    ->click('link or button') // fail if SomeException wasn't thrown or message doesn't match
;
```