### PR TITLE
Fail if trying to manipulate/assert on an "exception" page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "behat/mink": "^1.8",
         "symfony/browser-kit": "^5.4|^6.0",
         "symfony/css-selector": "^5.4|^6.0",
+        "symfony/dom-crawler": "^5.4|^6.0",
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/polyfill-php80": "^1.20",
         "zenstruck/assert": "^1.0",

--- a/src/Browser/KernelBrowser.php
+++ b/src/Browser/KernelBrowser.php
@@ -296,7 +296,9 @@ class KernelBrowser extends Browser
      */
     final public function assertStatus(int $expected): self
     {
-        $this->session()->assert()->statusCodeEquals($expected);
+        Assert::that($this->session()->getStatusCode())
+            ->is($expected, 'Current response status code is {actual}, but {expected} expected.')
+        ;
 
         return $this;
     }

--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -2,12 +2,14 @@
 
 namespace Zenstruck\Browser\Tests;
 
+use PHPUnit\Framework\AssertionFailedError;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\VarDumper\VarDumper;
+use Zenstruck\Assert;
 use Zenstruck\Browser;
 use Zenstruck\Browser\Test\HasBrowser;
 use Zenstruck\Browser\Tests\Fixture\TestComponent1;
@@ -599,6 +601,33 @@ trait BrowserTests
         ;
 
         $this->assertCount(2, $crawler);
+    }
+
+    /**
+     * @test
+     */
+    public function fails_if_trying_to_manipulate_exception_page(): void
+    {
+        Assert::that(function() {
+            $this->browser()
+                ->visit('/exception')
+                ->click('foo')
+            ;
+        })->throws(AssertionFailedError::class, 'The last request threw an exception: Zenstruck\Browser\Tests\Fixture\CustomException - exception thrown');
+
+        Assert::that(function() {
+            $this->browser()
+                ->visit('/exception')
+                ->fillField('foo', 'bar')
+            ;
+        })->throws(AssertionFailedError::class, 'The last request threw an exception: Zenstruck\Browser\Tests\Fixture\CustomException - exception thrown');
+
+        Assert::that(function() {
+            $this->browser()
+                ->visit('/exception')
+                ->assertSee('foo')
+            ;
+        })->throws(AssertionFailedError::class, 'The last request threw an exception: Zenstruck\Browser\Tests\Fixture\CustomException - exception thrown');
     }
 
     protected static function catchFileContents(string $expectedFile, callable $callback): string

--- a/tests/Fixture/CustomException.php
+++ b/tests/Fixture/CustomException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Zenstruck\Browser\Tests\Fixture;
+
+/**
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+final class CustomException extends \RuntimeException
+{
+}

--- a/tests/Fixture/Kernel.php
+++ b/tests/Fixture/Kernel.php
@@ -104,7 +104,7 @@ final class Kernel extends BaseKernel
 
     public function exception(): void
     {
-        throw new \Exception('exception thrown');
+        throw new CustomException('exception thrown');
     }
 
     public function redirect1(): RedirectResponse


### PR DESCRIPTION
Closes #47.

When trying to click an element, manipulate a form or make a "crawler" assertion, first check to ensure the page isn't a "standard Symfony debug exception page". If it is, fail with the parsed exception & message.