### PR TITLE
Add authentication assertions to `KernelBrowser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,12 +231,6 @@ $browser
     ->assertXml()
     ->assertHtml()
 
-    // authenticate a user for subsequent actions
-    ->actingAs($user) // \Symfony\Component\Security\Core\User\UserInterface
-
-    // If using zenstruck/foundry, you can pass a factory/proxy
-    ->actingAs(UserFactory::new())
-
     // by default, exceptions are caught and converted to a response
     // use the BROWSER_CATCH_EXCEPTIONS environment variable to change default
     // this disables that behaviour allowing you to use TestCase::expectException()
@@ -294,6 +288,35 @@ $queryCount = $browser
 $browser->use(function(\Symfony\Component\HttpKernel\DataCollector\RequestDataCollector $collector) {
     // ...
 })
+```
+
+#### Authentication
+
+The _KernelBrowser_ has helpers and assertions for authentication:
+
+```php
+/** @var \Zenstruck\Browser\KernelBrowser $browser **/
+
+$browser
+    // authenticate a user for subsequent actions
+    ->actingAs($user) // \Symfony\Component\Security\Core\User\UserInterface
+
+    // If using zenstruck/foundry, you can pass a factory/proxy
+    ->actingAs(UserFactory::new())
+
+    // fail if authenticated
+    ->assertNotAuthenticated()
+
+    // fail if NOT authenticated
+    ->assertAuthenticated()
+
+    // fails if NOT authenticated as "kbond"
+    ->assertAuthenticated('kbond')
+
+    // \Symfony\Component\Security\Core\User\UserInterface or, if using
+    // zenstruck/foundry, you can pass a factory/proxy
+    ->assertAuthenticated($user)
+;
 ```
 
 #### HTTP Requests

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/framework-bundle": "^5.4|^6.0",
         "symfony/polyfill-php80": "^1.20",
         "zenstruck/assert": "^1.0",
-        "zenstruck/callback": "^1.1"
+        "zenstruck/callback": "^1.4.2"
     },
     "require-dev": {
         "dbrekelmans/bdi": "^1.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -131,6 +131,16 @@ parameters:
 			path: src/Browser/HttpOptions.php
 
 		-
+			message: "#^Cannot call method getToken\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: src/Browser/KernelBrowser.php
+
+		-
+			message: "#^Cannot call method getUserIdentifier\\(\\) on Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\TokenInterface\\|null\\.$#"
+			count: 1
+			path: src/Browser/KernelBrowser.php
+
+		-
 			message: "#^Method Zenstruck\\\\Browser\\\\KernelBrowser\\:\\:delete\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Browser/KernelBrowser.php

--- a/tests/KernelBrowserTests.php
+++ b/tests/KernelBrowserTests.php
@@ -86,6 +86,45 @@ trait KernelBrowserTests
     /**
      * @test
      */
+    public function can_make_authentication_assertions(): void
+    {
+        // todo remove this requirement in foundry
+        Factory::boot(new Configuration());
+
+        $username = 'kevin';
+        $user = new InMemoryUser('kevin', 'pass');
+        $factory = factory(InMemoryUser::class, ['username' => 'kevin', 'password' => 'pass']);
+        $proxy = factory(InMemoryUser::class)->create(['username' => 'kevin', 'password' => 'pass']);
+
+        $this->browser()
+            ->assertNotAuthenticated()
+            ->actingAs($user)
+            ->assertAuthenticated()
+            ->assertAuthenticated($username)
+            ->assertAuthenticated($user)
+            ->assertAuthenticated($factory)
+            ->assertAuthenticated($proxy)
+            ->visit('/user')
+            ->assertAuthenticated()
+            ->assertAuthenticated($username)
+        ;
+    }
+
+    /**
+     * @test
+     */
+    public function can_check_if_not_authenticated_after_request(): void
+    {
+        $this->browser()
+            ->visit('/page1')
+            ->assertNotAuthenticated()
+            ->assertSeeIn('a', 'a link')
+        ;
+    }
+
+    /**
+     * @test
+     */
     public function can_enable_exception_throwing(): void
     {
         $this->expectException(\Exception::class);


### PR DESCRIPTION
```php
use Zenstruck\Browser\Component\Auth;

$this->browser()
    ->visit('/some/page')

    // fail if authenticated
    ->assertNotAuthenticated()

    ->actingAs($user)

    // fail if NOT authenticated
    ->assertAuthenticated()

    // fail if NOT authenticated or authenticated as a user other than "kevin"
    ->assertAuthenticated('kevin')
;
```