### PR TITLE
`Browser::saveCurrentState()` as "real" html

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -435,7 +435,7 @@ abstract class Browser
 
     public function saveCurrentState(string $filename): void
     {
-        $this->saveSource("{$filename}.txt");
+        $this->saveSource("{$filename}.html");
     }
 
     /**

--- a/src/Browser/Session.php
+++ b/src/Browser/Session.php
@@ -86,8 +86,10 @@ final class Session extends MinkSession
 
     public function source(): string
     {
+        $ret = "<!--\n";
+
         try {
-            $ret = "URL: {$this->getCurrentUrl()} ({$this->getStatusCode()})\n\n";
+            $ret .= "URL: {$this->getCurrentUrl()} ({$this->getStatusCode()})\n\n";
 
             foreach ($this->getResponseHeaders() as $header => $values) {
                 foreach ((array) $values as $value) {
@@ -98,7 +100,7 @@ final class Session extends MinkSession
             $ret = "URL: {$this->getCurrentUrl()}\n";
         }
 
-        $ret .= "\n";
+        $ret .= "-->\n";
 
         try {
             $ret .= $this->json();


### PR DESCRIPTION
When the PHPUnit extension saves the current state of html, save as a real HTML file (with the metadata inside a command).

Closes #85.