### PR TITLE
Fix debugging source when exception is detected

### DIFF
--- a/src/Browser/Session.php
+++ b/src/Browser/Session.php
@@ -103,7 +103,7 @@ final class Session extends MinkSession
         try {
             $ret .= $this->json();
         } catch (DriverException $e) {
-            $ret .= $this->page()->getContent();
+            $ret .= \trim($this->getDriver()->getContent());
         }
 
         return $ret;

--- a/tests/KernelBrowserTests.php
+++ b/tests/KernelBrowserTests.php
@@ -509,6 +509,22 @@ trait KernelBrowserTests
     /**
      * @test
      */
+    public function can_save_source_when_exception(): void
+    {
+        $contents = self::catchFileContents(__DIR__.'/../var/browser/source/source.txt', function() {
+            $this->browser()
+                ->visit('/invalid-page')
+                ->assertStatus(404)
+                ->saveSource('/source.txt')
+            ;
+        });
+
+        $this->assertStringContainsString('No route found for', $contents);
+    }
+
+    /**
+     * @test
+     */
     public function can_access_json_object(): void
     {
         $json = $this->browser()


### PR DESCRIPTION
Fixes an issue where you couldn't dump/dd/saveSource if an exception was detected (#81).