### PR TITLE
Fix typo in example AppBrowser use statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,7 +881,7 @@ use Zenstruck\Browser\KernelBrowser;
 
 class AppBrowser extends KernelBrowser
 {
-    use Authentication;
+    use AuthenticationExtension;
 }
 ```
 


### PR DESCRIPTION
Is this a typo?