### PR TITLE
[feature] Assert that an header is not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ $browser
     ->assertRedirected() // 3xx status code
     ->assertHeaderEquals('Content-Type', 'text/html; charset=UTF-8')
     ->assertHeaderContains('Content-Type', 'html')
+    ->assertHeaderEquals('X-Not-Present-Header', null)
 
     // helpers for quickly checking the content type
     ->assertJson()

--- a/src/Browser/KernelBrowser.php
+++ b/src/Browser/KernelBrowser.php
@@ -414,7 +414,7 @@ class KernelBrowser extends Browser
     /**
      * @return static
      */
-    final public function assertHeaderEquals(string $header, string $expected): self
+    final public function assertHeaderEquals(string $header, ?string $expected): self
     {
         $this->session()->assert()->responseHeaderEquals($header, $expected);
 

--- a/tests/KernelBrowserTests.php
+++ b/tests/KernelBrowserTests.php
@@ -233,6 +233,7 @@ trait KernelBrowserTests
             ->visit('/page1')
             ->assertHeaderEquals('Content-Type', 'text/html; charset=UTF-8')
             ->assertHeaderContains('Content-Type', 'text/html')
+            ->assertHeaderEquals('X-Not-Present-Header', null)
         ;
     }
 


### PR DESCRIPTION
Hi @kbond

This add the ability to assert that a header is not present is the response. This may be used when a header is added depending on a business rule.

Have a nice day