### PR TITLE
feat: migrate phpunit config-file to version 9

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
@@ -8,23 +7,24 @@
          failOnRisky="true"
          failOnWarning="true"
 >
-    <php>
-        <ini name="error_reporting" value="-1" />
-        <server name="KERNEL_CLASS" value="Zenstruck\Browser\Tests\Fixture\Kernel" />
-        <server name="SHELL_VERBOSITY" value="-1" />
-        <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
-        <server name="PANTHER_WEB_SERVER_DIR" value="./tests/Fixture/public"/>
-    </php>
+  <coverage>
+    <include>
+      <directory>./src/</directory>
+    </include>
+  </coverage>
 
-    <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <server name="KERNEL_CLASS" value="Zenstruck\Browser\Tests\Fixture\Kernel"/>
+    <server name="SHELL_VERBOSITY" value="-1"/>
+    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;max[direct]=0"/>
+    <server name="PANTHER_WEB_SERVER_DIR" value="./tests/Fixture/public"/>
+  </php>
 
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-        </whitelist>
-    </filter>
+  <testsuites>
+    <testsuite name="Project Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
+
 </phpunit>


### PR DESCRIPTION
Migrated vie the default --migration parameter.

`coverage` is added by default.