### PR TITLE
fix: enable attaching `\SplFileInfo` objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   fixcs:
     name: Run php-cs-fixer
     needs: sync-with-template
-    if: (github.event_name == 'push' || github.event_name == 'schedule') && !startsWith(github.ref, 'refs/tags')
+    if: (github.event_name == 'push' || github.event_name == 'schedule') && !startsWith(github.ref, 'refs/tags') && github.repository_owner == 'zenstruck'
     runs-on: ubuntu-latest
     steps:
       - uses: zenstruck/.github@php-cs-fixer
@@ -33,7 +33,7 @@ jobs:
 
   sync-with-template:
     name: Sync meta files
-    if: (github.event_name == 'push' || github.event_name == 'schedule') && !startsWith(github.ref, 'refs/tags')
+    if: (github.event_name == 'push' || github.event_name == 'schedule') && !startsWith(github.ref, 'refs/tags') && github.repository_owner == 'zenstruck'
     runs-on: ubuntu-latest
     steps:
       - uses: zenstruck/.github@sync-with-template

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -286,12 +286,12 @@ abstract class Browser
     }
 
     /**
-     * @param string[]|string $filename string: single file
+     * @param string|string[] $filename string: single file
      *                                  array: multiple files
      *
      * @return static
      */
-    final public function attachFile(string $selector, $filename): self
+    final public function attachFile(string $selector, array|string $filename): self
     {
         foreach ((array) $filename as $file) {
             if (!\file_exists($file)) {

--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -366,7 +366,7 @@ trait BrowserTests
             ->checkField('Input 2')
             ->uncheckField('Input 3')
             ->selectFieldOption('Input 4', 'option 2')
-            ->attachFile('Input 5', __FILE__)
+            ->attachFile('Input 5', new \SplFileInfo(__FILE__))
             ->selectFieldOptions('Input 6', ['option 1', 'option 3'])
             ->checkField('Radio 3')
             ->click('Submit')
@@ -547,7 +547,7 @@ trait BrowserTests
     {
         $this->browser()
             ->visit('/page1')
-            ->attachFile('Input 9', [__DIR__.'/Fixture/files/attachment.txt', __DIR__.'/Fixture/files/xml.xml'])
+            ->attachFile('Input 9', [__DIR__.'/Fixture/files/attachment.txt', new \SplFileInfo(__DIR__.'/Fixture/files/xml.xml')])
             ->click('Submit')
             ->assertContains('"input_9":["attachment.txt","xml.xml"]')
         ;

--- a/tests/PantherBrowserTest.php
+++ b/tests/PantherBrowserTest.php
@@ -189,7 +189,7 @@ final class PantherBrowserTest extends TestCase
     public function cannot_follow_invisible_link(): void
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectErrorMessage('Clickable element "invisible link" is not visible.');
+        $this->expectExceptionMessage('Clickable element "invisible link" is not visible.');
 
         $this->browser()
             ->visit('/javascript')


### PR DESCRIPTION
It was not possible to attach an `\SplFileInfo` object as it was cast to an array. Adding the `string|array` type-hint fixes this.