### PR TITLE
Fix asserting `json->decoded()` on zeros

### DIFF
--- a/src/Browser/Json.php
+++ b/src/Browser/Json.php
@@ -163,7 +163,15 @@ final class Json
      */
     public function decoded()
     {
-        return $this->decoded ??= empty($this->source) ? null : \json_decode($this->source, true, 512, \JSON_THROW_ON_ERROR);
+        if (isset($this->decoded)) {
+            return $this->decoded;
+        }
+
+        if ('' === trim($this->source)) {
+            return null;
+        }
+
+        return $this->decoded = \json_decode($this->source, true, 512, \JSON_THROW_ON_ERROR);
     }
 
     /**

--- a/tests/Fixture/Kernel.php
+++ b/tests/Fixture/Kernel.php
@@ -185,6 +185,7 @@ final class Kernel extends BaseKernel
             'profiler' => ['collect' => false],
             'session' => ['storage_factory_id' => 'session.storage.factory.mock_file'],
             'property_access' => true,
+            'http_method_override' => false,
         ]);
 
         $security = [

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -116,15 +116,17 @@ class JsonTest extends TestCase
      *
      * @dataProvider scalarChildAssertionProvider
      */
-    public function can_perform_assertion_on_scalar_child(string $selector, callable $asserter): void
+    public function can_perform_assertion_on_scalar_child(string $json, string $selector, callable $asserter): void
     {
-        (new Json('{"foo":{"bar":"baz"}}'))->assertThat($selector, $asserter);
+        (new Json($json))->assertThat($selector, $asserter);
     }
 
     public function scalarChildAssertionProvider(): iterable
     {
-        yield ['noop', function(Json $json) {$json->isNull(); }];
-        yield ['foo.bar', function(Json $json) {$json->isNotEmpty()->equals('baz'); }];
+        yield ['{"foo":{"bar":"baz"}}', 'noop', function(Json $json) {$json->isNull(); }];
+        yield ['{"foo":{"bar":"baz"}}', 'foo.bar', function(Json $json) {$json->isNotEmpty()->equals('baz'); }];
+        yield ['{"hydra:totalItems":0}', '"hydra:totalItems"', function(Json $json) {$json->is(0);}];
+        yield ['{"hydra":{"totalItems":0}}', 'hydra.totalItems', function(Json $json) {$json->is(0);}];
     }
 
     /**


### PR DESCRIPTION
Not sure why this was made this way, so proposing this because my assertion does not work with a real world example from api-platform endpoint :)

Additionally fixed:
> Since symfony/framework-bundle 6.1: Not setting the "framework.http_method_override" config option is deprecated. It will default to "false" in 7.0