### PR TITLE
fix: Complex test name normalization

### DIFF
--- a/src/Browser/Test/LegacyExtension.php
+++ b/src/Browser/Test/LegacyExtension.php
@@ -126,7 +126,7 @@ class LegacyExtension
         $normalized = \strtr($matches['test'], '\\:', '-_');
 
         if (isset($matches['dataset'])) {
-            $normalized .= '__data-set-'.preg_replace('/\W/', '-', $matches['dataset']);
+            $normalized .= '__data-set-'.preg_replace('/\W+/', '-', $matches['dataset']);
         }
 
         return $normalized;

--- a/src/Browser/Test/LegacyExtension.php
+++ b/src/Browser/Test/LegacyExtension.php
@@ -11,6 +11,7 @@
 
 namespace Zenstruck\Browser\Test;
 
+use PHPUnit\Runner\Version;
 use Zenstruck\Browser;
 
 /**
@@ -113,15 +114,19 @@ class LegacyExtension
 
     private static function normalizeTestName(string $name): string
     {
+        if (!strchr($name, 'with data set')) {
+            return \strtr($name, '\\:', '-_');
+        }
+
         // Try to match for a numeric data set index. If it didn't, match for a string one.
-        if (!\preg_match('#^([\w:\\\]+)(.+\#(\d+))#', $name, $matches)) {
-            \preg_match('#^([\w:\\\]+)(.+"([^"]+)")?#', $name, $matches);
+        if (!\preg_match('#^([\w:\\\]+) with data set \#(\d+)#', $name, $matches)) {
+            \preg_match('#^([\w:\\\]+) with data set "(.*)"#', $name, $matches);
         }
 
         $normalized = \strtr($matches[1], '\\:', '-_');
 
-        if (isset($matches[3])) {
-            $normalized .= '__data-set-'.\strtr($matches[3], '\\: ', '-_-');
+        if (isset($matches[2])) {
+            $normalized .= '__data-set-'.preg_replace('/\W/', '-', $matches[2]);
         }
 
         return $normalized;

--- a/src/Browser/Test/LegacyExtension.php
+++ b/src/Browser/Test/LegacyExtension.php
@@ -119,14 +119,14 @@ class LegacyExtension
         }
 
         // Try to match for a numeric data set index. If it didn't, match for a string one.
-        if (!\preg_match('#^([\w:\\\]+) with data set \#(\d+)#', $name, $matches)) {
-            \preg_match('#^([\w:\\\]+) with data set "(.*)"#', $name, $matches);
+        if (!\preg_match('#^(?<test>[\w:\\\]+) with data set \#(?<dataset>\d+)#', $name, $matches)) {
+            \preg_match('#^(?<test>[\w:\\\]+) with data set "(?<dataset>.*)"#', $name, $matches);
         }
 
-        $normalized = \strtr($matches[1], '\\:', '-_');
+        $normalized = \strtr($matches['test'], '\\:', '-_');
 
-        if (isset($matches[2])) {
-            $normalized .= '__data-set-'.preg_replace('/\W/', '-', $matches[2]);
+        if (isset($matches['dataset'])) {
+            $normalized .= '__data-set-'.preg_replace('/\W/', '-', $matches['dataset']);
         }
 
         return $normalized;

--- a/src/Browser/Test/LegacyExtension.php
+++ b/src/Browser/Test/LegacyExtension.php
@@ -11,7 +11,6 @@
 
 namespace Zenstruck\Browser\Test;
 
-use PHPUnit\Runner\Version;
 use Zenstruck\Browser;
 
 /**

--- a/tests/NormalizationTest.php
+++ b/tests/NormalizationTest.php
@@ -17,6 +17,26 @@ use Zenstruck\Browser\Test\LegacyExtension;
 
 final class NormalizationTest extends TestCase
 {
+    /**
+     * @test
+     * @dataProvider namesProvider
+     * @dataProvider edgeCaseTestNames
+     */
+    public function can_normalize_test_names(string $testName, string $expectedOutput): void
+    {
+        $browser = $this->createMock(Browser::class);
+        $browser
+            ->expects(self::once())
+            ->method('saveCurrentState')
+            ->with($expectedOutput);
+
+        $extension = new LegacyExtension();
+        $extension->executeBeforeFirstTest();
+        $extension->executeBeforeTest($testName);
+        $extension::registerBrowser($browser);
+        $extension->executeAfterTestError($testName, '', 0);
+    }
+
     public static function namesProvider(): \Generator
     {
         $baseTemplate = 'error_'.__METHOD__;
@@ -50,26 +70,6 @@ final class NormalizationTest extends TestCase
             'test name' => __METHOD__.' with data set #0 (test set)',
             'expected output' => $numericOutput,
         ];
-    }
-
-    /**
-     * @test
-     * @dataProvider namesProvider
-     * @dataProvider edgeCaseTestNames
-     */
-    public function can_normalize_test_names(string $testName, string $expectedOutput): void
-    {
-        $browser = $this->createMock(Browser::class);
-        $browser
-            ->expects(self::once())
-            ->method('saveCurrentState')
-            ->with($expectedOutput);
-
-        $extension = new LegacyExtension();
-        $extension->executeBeforeFirstTest();
-        $extension->executeBeforeTest($testName);
-        $extension::registerBrowser($browser);
-        $extension->executeAfterTestError($testName, '', 0);
     }
 
     public static function edgeCaseTestNames(): \Generator

--- a/tests/NormalizationTest.php
+++ b/tests/NormalizationTest.php
@@ -77,27 +77,27 @@ final class NormalizationTest extends TestCase
         $baseTemplate = \strtr('error_'.__METHOD__."__data-set-", '\\:', '-_');
         yield 'self within moustache' => [
             'test name' => __METHOD__.' with data set "te{{self}}st" (test set)',
-            'expected output' => $baseTemplate.'te--self--st__0',
+            'expected output' => $baseTemplate.'te-self-st__0',
         ];
         yield 'double quoted with space' => [
             'test name' => __METHOD__.' with data set "_self.env.setCache("uri://host.net:2121") _self.env.loadTemplate("other-host")" (test set)',
-            'expected output' => $baseTemplate.'_self-env-setCache--uri---host-net-2121---_self-env-loadTemplate--other-host--__0',
+            'expected output' => $baseTemplate.'_self-env-setCache-uri-host-net-2121-_self-env-loadTemplate-other-host-__0',
         ];
         yield 'double quotes in moustache' => [
             'test name' => __METHOD__.' with data set "te{{_self.env.registerUndefinedFilterCallback("exec")}}{{_self.env.getFilter("id")}}st"',
-            'expected output' => $baseTemplate.'te--_self-env-registerUndefinedFilterCallback--exec------_self-env-getFilter--id----st__0',
+            'expected output' => $baseTemplate.'te-_self-env-registerUndefinedFilterCallback-exec-_self-env-getFilter-id-st__0',
         ];
         yield 'escaped simple quote' => [
             'test name' => __METHOD__.' with data set "te{{\'/etc/passwd\'|file_excerpt(1,30)}}st"',
-             'expected output' => $baseTemplate.'te----etc-passwd--file_excerpt-1-30---st__0',
+             'expected output' => $baseTemplate.'te-etc-passwd-file_excerpt-1-30-st__0',
          ];
         yield 'single quote for array index access' => [
             'test name' => __METHOD__.' with data set "te{{[\'id\']|filter(\'system\')}}st"',
-            'expected output' => $baseTemplate.'te----id---filter--system----st__0',
+            'expected output' => $baseTemplate.'te-id-filter-system-st__0',
         ];
         yield 'numeric array access' => [
             'test name' => __METHOD__.' with data set "te{{[0]|reduce(\'system\',\'id\')}}st"',
-            'expected output' => $baseTemplate.'te---0--reduce--system---id----st__0',
+            'expected output' => $baseTemplate.'te-0-reduce-system-id-st__0',
         ];
     }
 }

--- a/tests/NormalizationTest.php
+++ b/tests/NormalizationTest.php
@@ -55,19 +55,49 @@ final class NormalizationTest extends TestCase
     /**
      * @test
      * @dataProvider namesProvider
+     * @dataProvider edgeCaseTestNames
      */
-    public function can_normalize_test_names(string $testName, string $normalizedName): void
+    public function can_normalize_test_names(string $testName, string $expectedOutput): void
     {
         $browser = $this->createMock(Browser::class);
         $browser
             ->expects(self::once())
             ->method('saveCurrentState')
-            ->with($normalizedName);
+            ->with($expectedOutput);
 
         $extension = new LegacyExtension();
         $extension->executeBeforeFirstTest();
         $extension->executeBeforeTest($testName);
         $extension::registerBrowser($browser);
         $extension->executeAfterTestError($testName, '', 0);
+    }
+
+    public static function edgeCaseTestNames(): \Generator
+    {
+        $baseTemplate = \strtr('error_'.__METHOD__."__data-set-", '\\:', '-_');
+        yield 'self within moustache' => [
+            'test name' => __METHOD__.' with data set "te{{self}}st" (test set)',
+            'expected output' => $baseTemplate.'te--self--st__0',
+        ];
+        yield 'double quoted with space' => [
+            'test name' => __METHOD__.' with data set "_self.env.setCache("uri://host.net:2121") _self.env.loadTemplate("other-host")" (test set)',
+            'expected output' => $baseTemplate.'_self-env-setCache--uri---host-net-2121---_self-env-loadTemplate--other-host--__0',
+        ];
+        yield 'double quotes in moustache' => [
+            'test name' => __METHOD__.' with data set "te{{_self.env.registerUndefinedFilterCallback("exec")}}{{_self.env.getFilter("id")}}st"',
+            'expected output' => $baseTemplate.'te--_self-env-registerUndefinedFilterCallback--exec------_self-env-getFilter--id----st__0',
+        ];
+        yield 'escaped simple quote' => [
+            'test name' => __METHOD__.' with data set "te{{\'/etc/passwd\'|file_excerpt(1,30)}}st"',
+             'expected output' => $baseTemplate.'te----etc-passwd--file_excerpt-1-30---st__0',
+         ];
+        yield 'single quote for array index access' => [
+            'test name' => __METHOD__.' with data set "te{{[\'id\']|filter(\'system\')}}st"',
+            'expected output' => $baseTemplate.'te----id---filter--system----st__0',
+        ];
+        yield 'numeric array access' => [
+            'test name' => __METHOD__.' with data set "te{{[0]|reduce(\'system\',\'id\')}}st"',
+            'expected output' => $baseTemplate.'te---0--reduce--system---id----st__0',
+        ];
     }
 }


### PR DESCRIPTION
Hello!

As a Christmas gift I come here to preset the work to hopefully close #67 properly :santa: :partying_face:

I added the cases suggested by @0x346e3730 based on the existing test cases of @raneomik.

Let me know if the new algorithm is ok for you.
The regexes are a bit stricter as there is `with data set` into, that's why I return early on line 117. It make the regexes a bit easier to read I think. That's not perfect to my eyes (depending on a static string is not algorithmically valid to me) but it may be enough. WDYT?
I will also create named group to make the code clearer.

I didn't set cases stated by er1z in the issue as he didn't explain much about its problem.

If you look at it during this long weekend, please don't merge. I wanted to sign my commits but I have some issue with my passphrase memory :sweat_smile: 

Thanks and have a nice week-end!

[EDIT]: Failing test seems unrelated.