### PR TITLE
[2.x] feat!: have `assert(Not)SeeIn()` look in all matching node's text

### DIFF
--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -226,6 +226,18 @@ trait BrowserTests
     /**
      * @test
      */
+    public function assert_see_in_multiple_elements(): void
+    {
+        $this->browser()
+            ->visit('/page1')
+            ->assertSeeIn('ul li', 'list 2')
+            ->assertNotSeeIn('ul li', 'something')
+        ;
+    }
+
+    /**
+     * @test
+     */
     public function can_dump_response(): void
     {
         $output = self::catchVarDumperOutput(function() {


### PR DESCRIPTION
Given the following html:

```html
<ul>
    <li>item 1</li>
    <li>item 2</li>
</ul>
```

Currently, this is the behaviour:

```php
$browser->assertSeeIn('li', 'item1'); // pass as this is the first li in the dom
$browser->assertSeeIn('li', 'item2'); // fail
```

I think, in 2.x, the second should also pass.

