### PR TITLE
Allow selectFieldOptions to deselect all values

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -281,6 +281,12 @@ abstract class Browser
      */
     final public function selectFieldOptions(string $selector, array $values): self
     {
+        if (empty($values)) {
+            $this->session->page()->fillField($selector, $values);
+
+            return $this;
+        }
+
         foreach ($values as $value) {
             $this->session()->page()->selectFieldOption($selector, $value, true);
         }

--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -389,6 +389,7 @@ trait BrowserTests
             ->selectFieldOption('Input 4', 'option 2')
             ->attachFile('Input 5', new \SplFileInfo(__FILE__))
             ->selectFieldOptions('Input 6', ['option 1', 'option 3'])
+            ->selectFieldOptions('Input 7', [])
             ->checkField('Radio 3')
             ->click('Submit')
             ->assertOn('/submit-form')
@@ -398,6 +399,7 @@ trait BrowserTests
             ->assertContains('"input_4":"option 2"')
             ->assertContains(\sprintf('"input_5":"%s"', \pathinfo(__FILE__, \PATHINFO_BASENAME)))
             ->assertContains('"input_6":["option 1","option 3"]')
+            ->assertNotContains('"input_7')
             ->assertContains('"input_8":"option 3"')
         ;
     }
@@ -415,6 +417,7 @@ trait BrowserTests
             ->selectFieldOption('input4', 'option 2')
             ->attachFile('input5', __FILE__)
             ->selectFieldOptions('input6', ['option 1', 'option 3'])
+            ->selectFieldOptions('input7', [])
             ->checkField('radio3')
             ->click('Submit')
             ->assertOn('/submit-form')
@@ -424,6 +427,7 @@ trait BrowserTests
             ->assertContains('"input_4":"option 2"')
             ->assertContains(\sprintf('"input_5":"%s"', \pathinfo(__FILE__, \PATHINFO_BASENAME)))
             ->assertContains('"input_6":["option 1","option 3"]')
+            ->assertNotContains('"input_7')
             ->assertContains('"input_8":"option 3"')
         ;
     }


### PR DESCRIPTION
I have a select multiple and in one of my test I need to unselect all values, I try  `->selectFieldOption('Réparateur(s)', [])` without result.

The method `selectFieldOptions` use a foreach and the`selectFieldOption` of Mink and so do nothing when I pass an empty array.

After some digging, I found that Mink use the following syntax to do that : `->page()->fillField($selector, []);` (see https://github.com/minkphp/Mink/issues/374#issuecomment-83586667).