### PR TITLE
minor: set KernelBrowser:: protected

### DIFF
--- a/src/Browser/KernelBrowser.php
+++ b/src/Browser/KernelBrowser.php
@@ -32,7 +32,7 @@ use Zenstruck\Foundry\Proxy;
  */
 class KernelBrowser extends Browser
 {
-    private ?HttpOptions $defaultHttpOptions = null;
+    protected ?HttpOptions $defaultHttpOptions = null;
 
     /**
      * @internal


### PR DESCRIPTION
this would be useful when extending `\Zenstruck\Browser\KernelBrowser` with a custom class in userland