### PR TITLE
Add hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ There are several environment variables available to configure:
 | `PANTHER_BROWSER_CLASS`          | `PantherBrowser` class to use.                                                                                         | `Zenstruck\Browser\PantherBrowser` |
 | `PANTHER_NO_HEADLESS`            | Disable headless-mode and allow usage of `PantherBrowser::pause()`.                                                    | `0` _(false)_                      |
 | `BROWSER_ALWAYS_START_WEBSERVER` | Always start a webserver configured for your current test env before running tests (only applies to `PantherBrowser`). | `0` _(false)_                      |
+| `BROWSER_FILE_LINK_FORMAT`       | Turns file paths seen in `Saved Source Files` into links that open those files right inside your browser               | `file://%f#L%l`                    |
 
 ## Extending
 

--- a/src/Browser/Test/LegacyExtension.php
+++ b/src/Browser/Test/LegacyExtension.php
@@ -11,7 +11,14 @@
 
 namespace Zenstruck\Browser\Test;
 
+use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
+use Symfony\Component\HttpKernel\Debug\FileLinkFormatter as LegacyFileLinkFormatter;
 use Zenstruck\Browser;
+
+if (!class_exists(FileLinkFormatter::class) && class_exists(LegacyFileLinkFormatter::class)) {
+    class_alias(LegacyFileLinkFormatter::class, FileLinkFormatter::class);
+}
+
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -24,6 +31,12 @@ class LegacyExtension
 
     /** @var array<string,array<string,string[]>> */
     private array $savedArtifacts = [];
+    private FileLinkFormatter $fileLinkFormatter;
+
+    public function __construct(FileLinkFormatter|null $fileLinkFormatter = null)
+    {
+        $this->fileLinkFormatter = $fileLinkFormatter ?? new FileLinkFormatter($_ENV['BROWSER_FILE_LINK_FORMAT'] ?? $_SERVER['BROWSER_FILE_LINK_FORMAT'] ?? '');
+    }
 
     /**
      * @internal
@@ -77,7 +90,7 @@ class LegacyExtension
                 echo "\n    {$category}:";
 
                 foreach ($artifacts as $artifact) {
-                    echo "\n      * {$artifact}:";
+                    echo "\n      * \033]8;;{$this->fileLinkFormatter->format(realpath($artifact) ?: '', 1)}\033\\$artifact\033]8;;\033\\";
                 }
             }
         }

--- a/src/Browser/Test/LegacyExtension.php
+++ b/src/Browser/Test/LegacyExtension.php
@@ -12,13 +12,7 @@
 namespace Zenstruck\Browser\Test;
 
 use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
-use Symfony\Component\HttpKernel\Debug\FileLinkFormatter as LegacyFileLinkFormatter;
 use Zenstruck\Browser;
-
-if (!class_exists(FileLinkFormatter::class) && class_exists(LegacyFileLinkFormatter::class)) {
-    class_alias(LegacyFileLinkFormatter::class, FileLinkFormatter::class);
-}
-
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -31,12 +25,7 @@ class LegacyExtension
 
     /** @var array<string,array<string,string[]>> */
     private array $savedArtifacts = [];
-    private FileLinkFormatter $fileLinkFormatter;
-
-    public function __construct(FileLinkFormatter|null $fileLinkFormatter = null)
-    {
-        $this->fileLinkFormatter = $fileLinkFormatter ?? new FileLinkFormatter($_ENV['BROWSER_FILE_LINK_FORMAT'] ?? $_SERVER['BROWSER_FILE_LINK_FORMAT'] ?? '');
-    }
+    private ?FileLinkFormatter $fileLinkFormatter = null;
 
     /**
      * @internal
@@ -90,7 +79,7 @@ class LegacyExtension
                 echo "\n    {$category}:";
 
                 foreach ($artifacts as $artifact) {
-                    echo "\n      * \033]8;;{$this->fileLinkFormatter->format(realpath($artifact) ?: '', 1)}\033\\$artifact\033]8;;\033\\";
+                    echo "\n      * {$this->hyperlink($artifact)}";
                 }
             }
         }
@@ -104,6 +93,26 @@ class LegacyExtension
     public function executeAfterTestFailure(string $test, string $message, float $time): void
     {
         self::saveBrowserStates($test, 'failure');
+    }
+
+    /**
+     * Only a terminal renders OSC 8 hyperlinks - piped output (ci logs, files) must stay plain.
+     */
+    private function hyperlink(string $artifact): string
+    {
+        if (!\stream_isatty(\STDOUT) || false !== \getenv('NO_COLOR')) {
+            return $artifact;
+        }
+
+        $this->fileLinkFormatter ??= new FileLinkFormatter(
+            $_ENV['BROWSER_FILE_LINK_FORMAT'] ?? $_SERVER['BROWSER_FILE_LINK_FORMAT'] ?? 'file://%f#L%l',
+        );
+
+        if (!$link = $this->fileLinkFormatter->format(\realpath($artifact) ?: '', 1)) {
+            return $artifact;
+        }
+
+        return "\033]8;;{$link}\033\\{$artifact}\033]8;;\033\\";
     }
 
     private static function saveBrowserStates(string $test, string $type): void


### PR DESCRIPTION
Turns file paths seen in `Saved Source Files` into links that open those files right inside your browser

Enable the `Zenstruck\Browser\Test\BrowserExtension` extension .
Configure the file link format with the environment variable `BROWSER_FILE_LINK_FORMAT`, the default value is `file://%f#L%l`

Can be overloaded in the `phpunit.xml.dist` for example

```
<server name="BROWSER_FILE_LINK_FORMAT" value="'file://%f#L%l"/>
```

Useful when running your app in a container or in a virtual machine, see Symfony doc https://symfony.com/doc/current/reference/configuration/framework.html#ide