### PR TITLE
Fix false positive on jsonMatches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: zenstruck/.github/actions/php-cs-fixer@main
         with:
-          php: 8.4
+          php: 8.0
           key: ${{ secrets.GPG_PRIVATE_KEY }}
           token: ${{ secrets.COMPOSER_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
     steps:
       - uses: zenstruck/.github/actions/php-cs-fixer@main
         with:
+          php: 8.4
           key: ${{ secrets.GPG_PRIVATE_KEY }}
           token: ${{ secrets.COMPOSER_TOKEN }}
 

--- a/src/Browser/Json.php
+++ b/src/Browser/Json.php
@@ -59,7 +59,7 @@ final class Json
      */
     public function assertMatches(string $expression, $expected): self
     {
-        Assert::that($this->search($expression))->is($expected);
+        Assert::that($this->search($expression))->equals($expected);
 
         return $this;
     }

--- a/tests/JsonTest.php
+++ b/tests/JsonTest.php
@@ -188,4 +188,10 @@ class JsonTest extends TestCase
                 JSON,
         );
     }
+
+    /** @test */
+    public function assoc_array_equals()
+    {
+        (new Json('{"foo": "bar", "bar": "baz"}'))->assertMatches('@', ['bar' => 'baz', 'foo' => 'bar']);
+    }
 }


### PR DESCRIPTION
relates to #127 

As far as I understood it, it's due to `Assert::is` which is the same as `assertSame` of phpunit.

I switched to `Assert::equals` which is the same as `assertEquals` of phpunit.

The error will now be throw only if two array:list are compared.

As it's not an issue for a json object to have a different index order, this fix is fine to me. Let me know if there is another option you have in mind.

The message comes from [`zenstruck/assert` library](https://github.com/zenstruck/assert/blob/b9a37a5f49995d606acee31d2bdc3179117a3520/src/Assert/AssertionFailed.php#L84) but I don't think we can improve that...