### PR TITLE
Removed the deprecated `ReflectionProperty::setAccessible()` call

### DIFF
--- a/src/Browser/Session/Driver/BrowserKitDriver.php
+++ b/src/Browser/Session/Driver/BrowserKitDriver.php
@@ -695,8 +695,6 @@ final class BrowserKitDriver extends Driver
             }
 
             $nodeReflection = (new \ReflectionObject($field))->getProperty('node');
-            $nodeReflection->setAccessible(true);
-
             $node = $nodeReflection->getValue($field);
 
             if ('button' === $node->nodeName || \in_array($node->getAttribute('type'), ['submit', 'button', 'image'])) {


### PR DESCRIPTION
* fixes #186

## Summary
Remove the deprecated `ReflectionProperty::setAccessible()` call that causes a deprecation warning in PHP 8.5.

## Background
- `ReflectionProperty::setAccessible()` is deprecated since PHP 8.5
- The method has had no effect since PHP 8.1 (reflection can access private/protected members without it)
- CI already tests PHP 8.5 via the external workflow `zenstruck/.github/.github/workflows/php-test-symfony.yml`

> [!NOTE]  
> Errors in the tests aren't related to this change