### PR TITLE
chore: support Symfony 8 on branch 2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.2, 8.3]
+        php: [8.3, 8.4]
         deps: [highest]
         symfony: [6.4.*, 7.4.*]
         include:
-          - php: 8.1
-            deps: lowest
-            symfony: '*'
-          - php: 8.4
+          - php: 8.5
             symfony: '8.0.*'
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
         deps: [highest]
         symfony: [6.4.*, 7.4.*, 8.0.*]
         include:
           - php: 8.1
             deps: lowest
             symfony: '*'
-        exclude:
-          - php: 8.1
-            symfony: 7.0.*
+
     steps:
       - uses: zenstruck/.github/actions/php-test-symfony@main
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: [8.2, 8.3, 8.4]
+        php: [8.2, 8.3]
         deps: [highest]
-        symfony: [6.4.*, 7.4.*, 8.0.*]
+        symfony: [6.4.*, 7.4.*]
         include:
           - php: 8.1
             deps: lowest
             symfony: '*'
+          - php: 8.4
+            symfony: '8.0.*'
 
     steps:
       - uses: zenstruck/.github/actions/php-test-symfony@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         php: [8.1, 8.2, 8.3]
         deps: [highest]
-        symfony: [6.4.*, 7.0.*]
+        symfony: [6.4.*, 7.4.*, 8.0.*]
         include:
           - php: 8.1
             deps: lowest

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     ],
     "require": {
         "php": ">=8.1",
-        "symfony/browser-kit": "^6.4|^7.0",
-        "symfony/css-selector": "^6.4|^7.0",
-        "symfony/dom-crawler": "^6.4|^7.0",
-        "symfony/framework-bundle": "^6.4|^7.0",
+        "symfony/browser-kit": "^6.4|^7.0|^8.0",
+        "symfony/css-selector": "^6.4|^7.0|^8.0",
+        "symfony/dom-crawler": "^6.4|^7.0|^8.0",
+        "symfony/framework-bundle": "^6.4|^7.0|^8.0",
         "zenstruck/assert": "^1.4",
         "zenstruck/callback": "^1.4.2",
         "zenstruck/dom": "^1.0"
@@ -29,8 +29,8 @@
         "phpunit/phpunit": "^9.6.21|^10.4",
         "symfony/mime": "^6.4|^7.0",
         "symfony/panther": "^2.1.0",
-        "symfony/phpunit-bridge": "^6.0|^7.0",
-        "symfony/security-bundle": "^6.4|^7.0"
+        "symfony/phpunit-bridge": "^6.0|^7.0|^8.0",
+        "symfony/security-bundle": "^6.4|^7.0|^8.0"
     },
     "suggest": {
         "justinrainbow/json-schema": "Json schema validator. Needed to use Json::assertMatchesSchema().",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.3",
         "symfony/browser-kit": "^6.4|^7.0|^8.0",
         "symfony/css-selector": "^6.4|^7.0|^8.0",
         "symfony/dom-crawler": "^6.4|^7.0|^8.0",

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -14,6 +14,8 @@ namespace Zenstruck;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\BrowserKit\CookieJar;
+use Symfony\Component\BrowserKit\Request;
+use Symfony\Component\BrowserKit\Response;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Filesystem\Filesystem;
 use Zenstruck\Browser\Assertion\SameUrlAssertion;
@@ -57,6 +59,9 @@ abstract class Browser
         $this->sourceDebug = $options['source_debug'] ?? false;
     }
 
+    /**
+     * @return AbstractBrowser<Request, Response>
+     */
     final public function client(): AbstractBrowser
     {
         return $this->session->client();

--- a/src/Browser/Session.php
+++ b/src/Browser/Session.php
@@ -12,6 +12,8 @@
 namespace Zenstruck\Browser;
 
 use Symfony\Component\BrowserKit\AbstractBrowser;
+use Symfony\Component\BrowserKit\Request;
+use Symfony\Component\BrowserKit\Response;
 use Zenstruck\Dom;
 use Zenstruck\Dom\Session as DomSession;
 
@@ -22,10 +24,16 @@ use Zenstruck\Dom\Session as DomSession;
  */
 abstract class Session implements DomSession
 {
+    /**
+     * @param AbstractBrowser<Request, Response> $client
+     */
     public function __construct(private AbstractBrowser $client)
     {
     }
 
+    /**
+     * @return AbstractBrowser<Request, Response>
+     */
     final public function client(): AbstractBrowser
     {
         return $this->client;


### PR DESCRIPTION
This pull request updates the Symfony dependencies to support Symfony 8.0 and expands the CI matrix to test against new Symfony versions. These changes ensure compatibility with the latest Symfony releases and improve test coverage.

Dependency updates:

* Updated the required versions of `symfony/browser-kit`, `symfony/css-selector`, `symfony/dom-crawler`, and `symfony/framework-bundle` in `composer.json` to include support for Symfony 8.0.
* Updated the required versions of `symfony/phpunit-bridge` and `symfony/security-bundle` in `composer.json` to include support for Symfony 8.0.

CI configuration:

* Expanded the Symfony versions in the GitHub Actions workflow matrix in `.github/workflows/ci.yml` to test against Symfony 7.4.* and 8.0.* in addition to the existing versions.