### PR TITLE
chore!: bump minimum PHP version to 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: zenstruck/.github/actions/php-cs-fixer@main
         with:
-          php: 8.0
+          php: 8.2
           key: ${{ secrets.GPG_PRIVATE_KEY }}
           token: ${{ secrets.COMPOSER_TOKEN }}
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "behat/mink": "^1.8",
         "symfony/browser-kit": "^6.4|^7.0|^8.0",
         "symfony/css-selector": "^6.4|^7.0|^8.0",


### PR DESCRIPTION
PHP 8.1 is end-of-life, and the CI matrix already starts at 8.2 — so 8.1 was declared but never tested.

Also bumps the `php-cs-fixer` job, which was pinned to 8.0, two majors below the floor.