### PR TITLE
fix: detect Symfony 7.4+ exception pages

### DIFF
--- a/src/Browser/Session.php
+++ b/src/Browser/Session.php
@@ -169,18 +169,51 @@ final class Session extends MinkSession
             ZenstruckAssert::fail('A request has not yet been made.');
         }
 
-        $crawler = $this->client()->getCrawler();
-
-        if (!\count($exceptionClassNode = $crawler->filter('.trace-details .trace-class')->first())) {
+        // an exception page always carries an error status: this runs before every action and
+        // assertion, so successful responses are never inspected
+        if (!$this->couldBeExceptionPage()) {
             return;
         }
 
-        $messageNode = $crawler->filter('.exception-message-wrapper .exception-message')->first();
+        $crawler = $this->client()->getCrawler();
 
-        ZenstruckAssert::fail('The last request threw an exception: %s - %s', [
-            \preg_replace('/\s+/', '', $exceptionClassNode->text()),
-            \count($messageNode) ? $messageNode->text() : 'unknown message',
-        ]);
+        // Symfony < 7.4 renders an html exception page
+        if (\count($exceptionClassNode = $crawler->filter('.trace-details .trace-class')->first())) {
+            $messageNode = $crawler->filter('.exception-message-wrapper .exception-message')->first();
+
+            $this->failWithException(
+                (string) \preg_replace('/\s+/', '', $exceptionClassNode->text()),
+                \count($messageNode) ? $messageNode->text() : 'unknown message',
+            );
+        }
+
+        // 7.4+ dumps the exception with var-dumper, which is not html when rendered from the cli
+        // not page(), which calls back into here
+        $content = \ltrim($this->getDriver()->getContent());
+
+        if (!\preg_match('/^([A-Za-z_\\\\][\w\\\\]*) \{#\d+/', $content, $exception)) {
+            return;
+        }
+
+        $this->failWithException(
+            $exception[1],
+            \preg_match('/#message: "([^"]*)"/', $content, $message) ? $message[1] : 'unknown message',
+        );
+    }
+
+    private function couldBeExceptionPage(): bool
+    {
+        try {
+            return $this->getStatusCode() >= 400;
+        } catch (DriverException) {
+            // the driver cannot tell us, so fall through to inspecting the response itself
+            return true;
+        }
+    }
+
+    private function failWithException(string $class, string $message): void
+    {
+        ZenstruckAssert::fail('The last request threw an exception: %s - %s', [$class, $message]);
     }
 
     private function isTextContent(): bool

--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -17,7 +17,6 @@ use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\BrowserKit\CookieJar;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\VarDumper\VarDumper;
 use Zenstruck\Assert;
 use Zenstruck\Browser;
@@ -644,10 +643,6 @@ trait BrowserTests
      */
     public function fails_if_trying_to_manipulate_exception_page(): void
     {
-        if (Kernel::VERSION_ID >= 70400) {
-            $this->markTestIncomplete('Symfony 7.4+ changed exception page structure.');
-        }
-
         Assert::that(function() {
             $this->browser()
                 ->visit('/exception')


### PR DESCRIPTION
`Session::ensureNoException()` scraped the exception page with `.trace-details .trace-class` and `.exception-message-wrapper .exception-message`. Symfony 7.4 renders exceptions with `var-dumper` instead, and under the CLI SAPI that output isn't even html:

```
Zenstruck\Browser\Tests\Fixture\CustomException {#4853 #message: "exception thrown" …
```

Both selectors matched nothing, so the method returned early and `fails_if_trying_to_manipulate_exception_page` could only be marked incomplete on 7.4+. The old path is kept for < 7.4, the dump format is now recognised alongside it, and the guard on the test is gone.

The status check moved to the top as a side effect: an exception page always carries a 4xx/5xx, and this runs before *every* action and assertion, so successful responses are no longer inspected at all. It falls through when a driver cannot report a status (Panther throws), preserving the old behaviour there.

Verified on Symfony 8.1.4 and 6.4.43 — the test passes with 12 assertions on each.
