### PR TITLE
feat(playwright): use the playwright bundle configuration when registered

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,10 @@ composer require --dev playwright-php/playwright-symfony
 vendor/bin/playwright-install --browsers
 ```
 
+> [!NOTE]
+> If `PlaywrightSymfonyBundle` is registered and enabled, its configuration (base url, intercepted
+> hosts, asset server) is used.
+
 It requires your test to extend `KernelTestCase` (or `WebTestCase`):
 
 ```php

--- a/src/Browser/Test/HasBrowser.php
+++ b/src/Browser/Test/HasBrowser.php
@@ -14,6 +14,7 @@ namespace Zenstruck\Browser\Test;
 use PHPUnit\Framework\Attributes\After;
 use Playwright\Symfony\Client\BrowserRegistry;
 use Playwright\Symfony\Client\BrowserSessionInterface;
+use Playwright\Symfony\Client\Interception\AssetServer;
 use Playwright\Symfony\Client\PlaywrightKernelClient;
 use Playwright\Symfony\Client\RequestConverter;
 use Playwright\Symfony\Client\ResponseConverter;
@@ -204,11 +205,24 @@ trait HasBrowser
 
         self::$playwrightKernel ??= static::bootKernel();
 
+        // the bundle is optional: its configuration is used when available. A disabled bundle
+        // registers no services or parameters at all, so this covers both
+        $container = self::$playwrightKernel->getContainer();
+        $hosts = $container->hasParameter('playwright.intercepted_hosts') ? $container->getParameter('playwright.intercepted_hosts') : null;
+
+        // the configured default is an env placeholder, so it is null unless PLAYWRIGHT_BASE_URL is set
+        $baseUrl = $container->hasParameter('playwright.base_url') ? $container->getParameter('playwright.base_url') : null;
+
         return new PlaywrightKernelClient(
             $session,
             self::$playwrightKernel,
             new RequestConverter(),
             new ResponseConverter(),
+            [],
+            \is_array($hosts) ? $hosts : null,
+            null,
+            $container->has(AssetServer::class) ? $container->get(AssetServer::class) : null,
+            \is_string($baseUrl) && '' !== $baseUrl ? $baseUrl : 'http://localhost',
         );
     }
 

--- a/tests/Fixture/Kernel.php
+++ b/tests/Fixture/Kernel.php
@@ -11,6 +11,7 @@
 
 namespace Zenstruck\Browser\Tests\Fixture;
 
+use Playwright\Symfony\PlaywrightSymfonyBundle;
 use Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -172,6 +173,7 @@ final class Kernel extends BaseKernel
     {
         yield new FrameworkBundle();
         yield new SecurityBundle();
+        yield new PlaywrightSymfonyBundle();
     }
 
     protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader): void


### PR DESCRIPTION
`HasBrowser` built the client with four arguments, so everything after them defaulted to null: the bundle's `AssetServer`, `playwright.base_url` and `playwright.intercepted_hosts` were all ignored. `PlaywrightTestCase` resolves them from the container, so behaviour differed by entry point.

The asset server is the one that hurts. It serves AssetMapper output without going through the kernel, and `framework.asset_mapper.server` defaults to `%kernel.debug%`, so an app whose test env runs with `APP_DEBUG=0` had every css and js request 404 - unstyled page, no javascript, which is the whole point of using a real browser.

The bundle stays optional: its configuration is used when it is registered and enabled, and its absence falls back to the previous defaults. The fixture app registers it, so the existing playwright tests now run through the resolved asset server, base url and intercepted hosts.

Closes #204. Thanks @ker0x for the diagnosis - it was accurate down to the service definition.
