### PR TITLE
fix: fail when acting on the browser after an expected exception

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -120,7 +120,7 @@ abstract class Browser
 
     final public function crawler(): Crawler
     {
-        return $this->client()->getCrawler();
+        return $this->session()->crawler();
     }
 
     final public function content(): string
@@ -223,7 +223,7 @@ abstract class Browser
      */
     public function assertStatus(int $expected): self
     {
-        Assert::that($this->session()->getStatusCode())
+        Assert::that($this->session()->statusCode())
             ->is($expected, 'Current response status code is {actual}, but {expected} expected.')
         ;
 
@@ -235,10 +235,12 @@ abstract class Browser
      */
     public function assertSuccessful(): self
     {
+        $statusCode = $this->session()->statusCode();
+
         Assert::true(
-            $this->session()->getStatusCode() >= 200 && $this->session()->getStatusCode() < 300,
+            $statusCode >= 200 && $statusCode < 300,
             'Expected successful status code (2xx) but got {actual}.',
-            ['actual' => $this->session()->getStatusCode()],
+            ['actual' => $statusCode],
         );
 
         return $this;

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -125,7 +125,7 @@ abstract class Browser
 
     final public function content(): string
     {
-        return $this->session()->page()->getContent();
+        return $this->session()->content();
     }
 
     /**

--- a/src/Browser/Session.php
+++ b/src/Browser/Session.php
@@ -83,6 +83,14 @@ final class Session extends MinkSession
         return $this->client()->getCrawler();
     }
 
+    public function content(): string
+    {
+        // reading an error page's body is legitimate: crawler() and saveSource() both allow it
+        $this->ensureResponseExists();
+
+        return $this->getPage()->getContent();
+    }
+
     public function isRedirect(): bool
     {
         return $this->getStatusCode() >= 300 && $this->getStatusCode() < 400;

--- a/src/Browser/Session.php
+++ b/src/Browser/Session.php
@@ -68,6 +68,21 @@ final class Session extends MinkSession
         return $this->getPage();
     }
 
+    public function statusCode(): int
+    {
+        // not ensureNoException(): asserting the status of an error page is legitimate
+        $this->ensureResponseExists();
+
+        return $this->getStatusCode();
+    }
+
+    public function crawler(): Crawler
+    {
+        $this->ensureResponseExists();
+
+        return $this->client()->getCrawler();
+    }
+
     public function isRedirect(): bool
     {
         return $this->getStatusCode() >= 300 && $this->getStatusCode() < 400;
@@ -168,7 +183,7 @@ final class Session extends MinkSession
         exit(1);
     }
 
-    private function ensureNoException(): void
+    private function ensureResponseExists(): void
     {
         if (!$this->isStarted()) {
             ZenstruckAssert::fail('A request has not yet been made.');
@@ -177,6 +192,11 @@ final class Session extends MinkSession
         if ($this->getDriver()->lastRequestThrewExpectedException()) {
             ZenstruckAssert::fail('The last request threw the expected exception: make another request before continuing.');
         }
+    }
+
+    private function ensureNoException(): void
+    {
+        $this->ensureResponseExists();
 
         // an exception page always carries an error status: this runs before every action and
         // assertion, so successful responses are never inspected
@@ -214,6 +234,7 @@ final class Session extends MinkSession
     private function couldBeExceptionPage(): bool
     {
         try {
+            // not statusCode(), which calls back into here
             return $this->getStatusCode() >= 400;
         } catch (DriverException) {
             // the driver cannot tell us, so fall through to inspecting the response itself

--- a/src/Browser/Session.php
+++ b/src/Browser/Session.php
@@ -174,6 +174,10 @@ final class Session extends MinkSession
             ZenstruckAssert::fail('A request has not yet been made.');
         }
 
+        if ($this->getDriver()->lastRequestThrewExpectedException()) {
+            ZenstruckAssert::fail('The last request threw the expected exception: make another request before continuing.');
+        }
+
         // an exception page always carries an error status: this runs before every action and
         // assertion, so successful responses are never inspected
         if (!$this->couldBeExceptionPage()) {

--- a/src/Browser/Session/Driver.php
+++ b/src/Browser/Session/Driver.php
@@ -33,6 +33,7 @@ abstract class Driver extends CoreDriver
     private $expectedException;
     private ?string $expectedExceptionMessage = null;
     private bool $catchExceptionsEnabled = true;
+    private bool $lastRequestThrewExpectedException = false;
 
     /**
      * @param AbstractBrowser<Request, Response> $client
@@ -68,6 +69,8 @@ abstract class Driver extends CoreDriver
     public function reset(): void
     {
         $this->client()->restart();
+
+        $this->lastRequestThrewExpectedException = false;
     }
 
     public function quit(): void
@@ -101,12 +104,23 @@ abstract class Driver extends CoreDriver
     abstract public function request(string $method, string $url, HttpOptions $options): void;
 
     /**
+     * Whether the last request threw the exception expected by expectException(): its response
+     * never existed, so whatever the client holds belongs to an earlier request.
+     */
+    public function lastRequestThrewExpectedException(): bool
+    {
+        return $this->lastRequestThrewExpectedException;
+    }
+
+    /**
      * Tell the client to stop, or resume, converting kernel exceptions into responses.
      */
     abstract protected function clientCatchExceptions(bool $catch): void;
 
     final protected function wrapRequest(callable $callback): void
     {
+        $this->lastRequestThrewExpectedException = false;
+
         if (!$this->expectedException) {
             $callback();
 
@@ -117,6 +131,8 @@ abstract class Driver extends CoreDriver
 
         try {
             Assert::that($callback)->throws($this->expectedException, $this->expectedExceptionMessage);
+
+            $this->lastRequestThrewExpectedException = true;
         } finally {
             // a request the browser has not finished can be handled after this one returns, so
             // leaving catching disabled would throw the same exception again, out of a later call

--- a/src/Browser/Session/Driver/BrowserKitDriver.php
+++ b/src/Browser/Session/Driver/BrowserKitDriver.php
@@ -105,19 +105,19 @@ final class BrowserKitDriver extends Driver
 
     public function reload(): void
     {
-        $this->client()->reload();
+        $this->wrapRequest(fn() => $this->client()->reload());
         $this->forms = [];
     }
 
     public function forward(): void
     {
-        $this->client()->forward();
+        $this->wrapRequest(fn() => $this->client()->forward());
         $this->forms = [];
     }
 
     public function back(): void
     {
-        $this->client()->back();
+        $this->wrapRequest(fn() => $this->client()->back());
         $this->forms = [];
     }
 

--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -229,6 +229,36 @@ trait BrowserTests
 
     /**
      * @test
+     *
+     * @dataProvider responseAccessorProvider
+     */
+    #[Test]
+    #[DataProvider('responseAccessorProvider')]
+    public function fails_if_reading_the_response_when_the_request_threw(callable $accessor): void
+    {
+        Assert::that(function() use ($accessor) {
+            $browser = $this->browser()
+                ->visit('/page1')
+                ->expectException(\Exception::class, 'exception thrown')
+                ->visit('/exception')
+            ;
+
+            $accessor($browser);
+        })->throws(AssertionFailedError::class, 'The last request threw the expected exception: make another request before continuing.');
+    }
+
+    /**
+     * These read the response without going through page(), so they need the check of their own.
+     */
+    public static function responseAccessorProvider(): iterable
+    {
+        yield 'assertStatus' => [fn(Browser $browser) => $browser->assertStatus(200)];
+        yield 'assertSuccessful' => [fn(Browser $browser) => $browser->assertSuccessful()];
+        yield 'crawler' => [fn(Browser $browser) => $browser->crawler()];
+    }
+
+    /**
+     * @test
      */
     #[Test]
     public function multiple_browsers(): void

--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -1304,6 +1304,17 @@ trait BrowserTests
         $this->assertStringContainsString('text content', $content);
     }
 
+    /**
+     * @test
+     */
+    #[Test]
+    public function can_get_content_of_an_exception_page(): void
+    {
+        $content = $this->browser()->visit('/exception')->content();
+
+        $this->assertStringContainsString('exception thrown', $content);
+    }
+
     protected static function catchFileContents(string $expectedFile, callable $callback): string
     {
         (new Filesystem())->remove($expectedFile);

--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -197,6 +197,40 @@ trait BrowserTests
      * @test
      */
     #[Test]
+    public function fails_if_acting_after_an_expected_exception(): void
+    {
+        // the throwing request never produced a response, the previous page is still loaded
+        Assert::that(function() {
+            $this->browser()
+                ->visit('/page1')
+                ->expectException(\Exception::class, 'exception thrown')
+                ->visit('/exception')
+                ->assertSee('h1 title')
+            ;
+        })->throws(AssertionFailedError::class, 'The last request threw the expected exception: make another request before continuing.');
+
+        // without a previous request there is no page at all
+        Assert::that(function() {
+            $this->browser()
+                ->expectException(\Exception::class, 'exception thrown')
+                ->visit('/exception')
+                ->click('a link')
+            ;
+        })->throws(AssertionFailedError::class, 'The last request threw the expected exception: make another request before continuing.');
+
+        // a new request makes the browser usable again
+        $this->browser()
+            ->expectException(\Exception::class, 'exception thrown')
+            ->visit('/exception')
+            ->visit('/page1')
+            ->assertSee('h1 title')
+        ;
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
     public function multiple_browsers(): void
     {
         $browser1 = $this->browser()


### PR DESCRIPTION
Fixes #202

Implements the proposal from the issue, in the shared layer so both browsers get the same behavior:

- `Driver::wrapRequest()` records that the expected exception was consumed (the flag is cleared by the next request and by `reset()`).
- `Session::ensureNoException()` already runs before every action and assertion, so it now fails fast with "The last request threw the expected exception: make another request before continuing." instead of leaking BrowserKit's `BadMethodCallException` or silently acting on the previous page.

The shared test covers the three cases from the issue: stale previous page, no previous request at all, and recovery once another request is made.

Thanks for writing the issue up with the proposal included, it basically reviewed itself. 😄
