### PR TITLE
test: unique artifact filenames to fix a race under paratest

### DIFF
--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -884,10 +884,11 @@ trait BrowserTests
     #[Test]
     public function can_save_source(): void
     {
-        $contents = self::catchFileContents(__DIR__.'/../var/browser/source/source.txt', function() {
+        $file = self::uniqueFilename('source.txt');
+        $contents = self::catchFileContents(__DIR__.'/../var/browser/source/'.$file, function() use ($file) {
             $this->browser()
                 ->visit('/page1')
-                ->saveSource('source.txt')
+                ->saveSource($file)
             ;
         });
 
@@ -901,15 +902,16 @@ trait BrowserTests
     #[Test]
     public function can_save_source_as_zip(): void
     {
-        $contents = self::catchFileContents(__DIR__.'/../var/browser/source/attachment.zip', function() {
+        $file = self::uniqueFilename('attachment.zip');
+        $contents = self::catchFileContents(__DIR__.'/../var/browser/source/'.$file, function() use ($file) {
             $this->browser()
                 ->visit('/zip')
-                ->saveSource('attachment.zip')
+                ->saveSource($file)
             ;
         });
 
         $this->assertEquals(
-            \file_get_contents(__DIR__.'/../var/browser/source/attachment.zip'),
+            \file_get_contents(__DIR__.'/../var/browser/source/'.$file),
             $contents,
         );
     }
@@ -1313,6 +1315,15 @@ trait BrowserTests
         $content = $this->browser()->visit('/exception')->content();
 
         $this->assertStringContainsString('exception thrown', $content);
+    }
+
+    /**
+     * Tests run concurrently (paratest --functional) and save into the same directories: a
+     * unique filename per save keeps them from reading each other's files.
+     */
+    protected static function uniqueFilename(string $filename): string
+    {
+        return \sprintf('%s-%s', \bin2hex(\random_bytes(4)), $filename);
     }
 
     protected static function catchFileContents(string $expectedFile, callable $callback): string

--- a/tests/KernelBrowserTests.php
+++ b/tests/KernelBrowserTests.php
@@ -345,10 +345,11 @@ trait KernelBrowserTests
     #[Test]
     public function can_save_formatted_json_source(): void
     {
-        $contents = self::catchFileContents(__DIR__.'/../var/browser/source/source.txt', function() {
+        $file = self::uniqueFilename('source.txt');
+        $contents = self::catchFileContents(__DIR__.'/../var/browser/source/'.$file, function() use ($file) {
             $this->browser()
                 ->visit('/http-method')
-                ->saveSource('/source.txt')
+                ->saveSource('/'.$file)
             ;
         });
 
@@ -362,11 +363,12 @@ trait KernelBrowserTests
     #[Test]
     public function can_save_source_when_exception(): void
     {
-        $contents = self::catchFileContents(__DIR__.'/../var/browser/source/source.txt', function() {
+        $file = self::uniqueFilename('source.txt');
+        $contents = self::catchFileContents(__DIR__.'/../var/browser/source/'.$file, function() use ($file) {
             $this->browser()
                 ->visit('/invalid-page')
                 ->assertStatus(404)
-                ->saveSource('/source.txt')
+                ->saveSource('/'.$file)
             ;
         });
 


### PR DESCRIPTION
`paratest --functional` runs test methods concurrently, and the file-saving tests all write to the same `var/browser/source` paths. `catchFileContents()` removes the file, runs the callback, then reads it back, so one test can read the file another test just wrote.

Seen on [this run](https://github.com/zenstruck/browser/actions/runs/32833110831) (#208's first CI pass): `can_save_formatted_json_source` failed with the exception dump from `can_save_source_when_exception` on one job, and the mirror image on another. The two tests come from the `KernelBrowserTests` trait, so two classes race on the same `source.txt` even across classes.

Each save now uses a unique filename (`random_bytes` prefix). With the fix I could no longer reproduce any `can_save_*` failure across 8 local `paratest --functional` runs.
