### PR TITLE
feat(playwright): auto-wait for actions and assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,9 @@ $browser
     ->assertVisible('.selector')
     ->assertNotVisible('.selector')
 
+    // change how long the calls that follow wait
+    ->timeout(5000)
+
     // wait x milliseconds
     ->wait(1000) // 1 second
 
@@ -586,6 +589,43 @@ $browser
 > [!NOTE]
 > Uncaught javascript errors are not included in the console log: Playwright reports these as a
 > separate `pageerror` event which `playwright-php` does not yet expose.
+
+#### Auto Waiting
+
+Actions and assertions wait for the page to catch up, so you rarely need an explicit wait. Clicking
+or filling a field waits for the element to turn up, an assertion is retried until it passes, and a
+"not" assertion passes as soon as it holds (immediately, if it already does). Everything gives up
+after `BROWSER_DEFAULT_TIMEOUT` milliseconds and fails.
+
+```php
+$this->browser()
+    ->visit('/my-page')
+
+    // no explicit wait needed: both wait for the element to appear
+    ->fillField('Search', 'zenstruck')
+    ->click('Search')
+
+    // retried until it passes, or the timeout expires
+    ->assertSeeIn('#results', 'zenstruck/browser')
+
+    // passes as soon as the spinner goes away
+    ->assertNotSeeElement('#spinner')
+;
+```
+
+> [!TIP]
+> This is particularly useful with [Turbo](https://turbo.hotwired.dev/), where visits, frames and
+> streams all update the page without a navigation to wait on. Assert something that only exists
+> after the update: content already on the page passes straight away.
+
+The timeout covers every wait, including the `wait*()` methods above. Page loads are the exception,
+whether from `visit()` or a click that navigates: those keep Playwright's own 30 second limit, since
+a cold kernel boot is far slower than anything you would want an assertion to wait for.
+
+> [!WARNING]
+> An assertion that is going to fail can only be reported as failed once the timeout expires, so
+> failures cost `BROWSER_DEFAULT_TIMEOUT` instead of returning instantly. Lower it, or call
+> `timeout()` for part of a test, if you would rather fail fast.
 
 ### Multiple Browser Instances
 
@@ -646,6 +686,7 @@ There are several environment variables available to configure:
 | `BROWSER_CONSOLE_LOG_DIR`  | Directory to save javascript console logs to (only applies to `PlaywrightBrowser`).             | `./var/browser/console-logs`          |
 | `BROWSER_FOLLOW_REDIRECTS` | Whether to follow redirects by default.                                                         | `1` _(true)_                          |
 | `BROWSER_CATCH_EXCEPTIONS` | Whether to catch exceptions by default.                                                         | `1` _(true)_                          |
+| `BROWSER_DEFAULT_TIMEOUT`  | Milliseconds actions and assertions wait before giving up (only applies to `PlaywrightBrowser`). | `2000`                                |
 | `BROWSER_SOURCE_DEBUG`     | Whether to add request metadata to written source files (only applies to `KernelBrowser`).      | `0` _(false)_                         |
 | `KERNEL_BROWSER_CLASS`     | `KernelBrowser` class to use.                                                                   | `Zenstruck\Browser\KernelBrowser`     |
 | `PLAYWRIGHT_BROWSER_CLASS` | `PlaywrightBrowser` class to use.                                                               | `Zenstruck\Browser\PlaywrightBrowser` |

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -289,6 +289,7 @@ abstract class Browser
      */
     final public function fillField(string $selector, string $value): self
     {
+        $this->awaitField($selector);
         $this->session()->page()->fillField($selector, $value);
 
         return $this;
@@ -299,7 +300,7 @@ abstract class Browser
      */
     final public function checkField(string $selector): self
     {
-        $field = $this->session()->page()->findField($selector);
+        $field = $this->awaitField($selector);
 
         if ($field && 'radio' === \mb_strtolower((string) $field->getAttribute('type'))) {
             $this->session()->page()->selectFieldOption($selector, (string) $field->getAttribute('value'));
@@ -317,6 +318,7 @@ abstract class Browser
      */
     final public function uncheckField(string $selector): self
     {
+        $this->awaitField($selector);
         $this->session()->page()->uncheckField($selector);
 
         return $this;
@@ -349,6 +351,7 @@ abstract class Browser
      */
     final public function selectFieldOption(string $selector, string $value): self
     {
+        $this->awaitField($selector);
         $this->session()->page()->selectFieldOption($selector, $value);
 
         return $this;
@@ -359,6 +362,8 @@ abstract class Browser
      */
     final public function selectFieldOptions(string $selector, array $values): self
     {
+        $this->awaitField($selector);
+
         if (!$values) {
             $this->session->page()->fillField($selector, $values);
 
@@ -380,6 +385,8 @@ abstract class Browser
      */
     final public function attachFile(string $selector, array|string $filename): self
     {
+        $this->awaitField($selector);
+
         foreach ((array) $filename as $file) {
             if (!\file_exists($file)) {
                 throw new \InvalidArgumentException(\sprintf('File "%s" does not exist.', $file));
@@ -791,18 +798,7 @@ abstract class Browser
 
     final protected function getClickableElement(string $selector): NodeElement
     {
-        // try button
-        $element = $this->session()->page()->findButton($selector);
-
-        if (!$element) {
-            // try link
-            $element = $this->session()->page()->findLink($selector);
-        }
-
-        if (!$element) {
-            // try by css
-            $element = $this->session()->page()->find('css', $selector);
-        }
+        $element = $this->session()->autoWait()->lookup(fn() => $this->findClickable($selector));
 
         if (!$element) {
             Assert::fail('Clickable element "%s" not found.', [$selector]);
@@ -878,5 +874,18 @@ abstract class Browser
         }
 
         return $container->get('security.token_storage')->getToken();
+    }
+
+    private function findClickable(string $selector): ?NodeElement
+    {
+        // try button, then link, then css
+        return $this->session()->page()->findButton($selector)
+            ?? $this->session()->page()->findLink($selector)
+            ?? $this->session()->page()->find('css', $selector);
+    }
+
+    private function awaitField(string $selector): ?NodeElement
+    {
+        return $this->session()->autoWait()->lookup(fn() => $this->session()->page()->findField($selector));
     }
 }

--- a/src/Browser/PlaywrightBrowser.php
+++ b/src/Browser/PlaywrightBrowser.php
@@ -30,6 +30,13 @@ use Zenstruck\Browser\Session\Playwright\CookieJar as PlaywrightCookieJar;
  */
 class PlaywrightBrowser extends Browser
 {
+    /**
+     * Playwright defaults to 30 seconds, and its assertions to 5. Both are calibrated for a browser
+     * talking to a remote app: the kernel client is in-process, and a failing assertion cannot be
+     * reported until this expires, so it is worth keeping short.
+     */
+    private const DEFAULT_TIMEOUT = 2000;
+
     private ?string $screenshotDir;
     private ?string $consoleLogDir;
 
@@ -59,6 +66,10 @@ class PlaywrightBrowser extends Browser
 
         $this->screenshotDir = $options['screenshot_dir'] ?? null;
         $this->consoleLogDir = $options['console_log_dir'] ?? null;
+
+        $this->timeout(
+            isset($options['default_timeout']) ? (int) $options['default_timeout'] : self::DEFAULT_TIMEOUT,
+        );
 
         // subscribe before anything is navigated to, or the messages are already gone
         // @todo also collect uncaught errors once playwright-php exposes the "pageerror" event
@@ -102,6 +113,23 @@ class PlaywrightBrowser extends Browser
     }
 
     /**
+     * How long actions and assertions wait for the page to catch up. Use a short timeout to fail
+     * fast.
+     *
+     * @return static
+     */
+    final public function timeout(int $milliseconds): self
+    {
+        if ($milliseconds < 1) {
+            throw new \InvalidArgumentException(\sprintf('Timeout must be a positive number of milliseconds, "%d" given.', $milliseconds));
+        }
+
+        $this->session()->getDriver()->setAutoWaitTimeout($milliseconds);
+
+        return $this;
+    }
+
+    /**
      * @return static
      */
     final public function wait(int $milliseconds): self
@@ -116,7 +144,7 @@ class PlaywrightBrowser extends Browser
      */
     final public function waitUntilVisible(string $selector): self
     {
-        $this->page()->waitForSelector($selector, ['state' => 'visible']);
+        $this->page()->waitForSelector($selector, ['state' => 'visible', 'timeout' => $this->currentTimeout()]);
 
         return $this;
     }
@@ -126,7 +154,7 @@ class PlaywrightBrowser extends Browser
      */
     final public function waitUntilNotVisible(string $selector): self
     {
-        $this->page()->waitForSelector($selector, ['state' => 'hidden']);
+        $this->page()->waitForSelector($selector, ['state' => 'hidden', 'timeout' => $this->currentTimeout()]);
 
         return $this;
     }
@@ -139,6 +167,7 @@ class PlaywrightBrowser extends Browser
         $this->page()->waitForFunction(
             '([selector, text]) => { const el = document.querySelector(selector); return null !== el && el.checkVisibility() && el.textContent.includes(text); }',
             [$selector, $expected],
+            ['timeout' => $this->currentTimeout()],
         );
 
         return $this;
@@ -152,6 +181,7 @@ class PlaywrightBrowser extends Browser
         $this->page()->waitForFunction(
             '([selector, text]) => { const el = document.querySelector(selector); return null === el || !el.checkVisibility() || !el.textContent.includes(text); }',
             [$selector, $expected],
+            ['timeout' => $this->currentTimeout()],
         );
 
         return $this;
@@ -262,6 +292,11 @@ class PlaywrightBrowser extends Browser
     protected function cookieJar(): CookieJar
     {
         return new PlaywrightCookieJar($this->page());
+    }
+
+    private function currentTimeout(): int
+    {
+        return $this->session()->autoWait()->timeout() ?? self::DEFAULT_TIMEOUT;
     }
 
     private function page(): PageInterface

--- a/src/Browser/Session.php
+++ b/src/Browser/Session.php
@@ -22,6 +22,7 @@ use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Response;
 use Zenstruck\Assert as ZenstruckAssert;
 use Zenstruck\Browser\Session\Assert;
+use Zenstruck\Browser\Session\AutoWait;
 use Zenstruck\Browser\Session\Driver;
 
 /**
@@ -58,7 +59,12 @@ final class Session extends MinkSession
     {
         $this->ensureNoException();
 
-        return new Assert(new WebAssert($this));
+        return new Assert(new WebAssert($this), $this->autoWait());
+    }
+
+    public function autoWait(): AutoWait
+    {
+        return $this->getDriver()->autoWait();
     }
 
     public function page(): DocumentElement

--- a/src/Browser/Session/Assert.php
+++ b/src/Browser/Session/Assert.php
@@ -24,11 +24,19 @@ use Zenstruck\Assert as ZenstruckAssert;
  */
 final class Assert
 {
-    private WebAssert $webAssert;
+    /**
+     * These read the response rather than the page: it cannot change while we poll, so retrying
+     * them would only make their failures slower.
+     */
+    private const NOT_RETRYABLE = ['responseHeaderEquals', 'responseHeaderContains'];
 
-    public function __construct(WebAssert $webAssert)
+    private WebAssert $webAssert;
+    private AutoWait $autoWait;
+
+    public function __construct(WebAssert $webAssert, AutoWait $autoWait)
     {
         $this->webAssert = $webAssert;
+        $this->autoWait = $autoWait;
     }
 
     /**
@@ -39,7 +47,7 @@ final class Assert
     public function __call(string $name, array $arguments)
     {
         try {
-            $ret = $this->webAssert->{$name}(...$arguments);
+            $ret = $this->run($name, $arguments);
         } catch (ExpectationException $e) {
             ZenstruckAssert::fail($e->getMessage());
         }
@@ -47,5 +55,17 @@ final class Assert
         ZenstruckAssert::pass();
 
         return $ret;
+    }
+
+    /**
+     * @param mixed[] $arguments
+     */
+    private function run(string $name, array $arguments): mixed
+    {
+        if (\in_array($name, self::NOT_RETRYABLE, true)) {
+            return $this->webAssert->{$name}(...$arguments);
+        }
+
+        return $this->autoWait->assertion(fn() => $this->webAssert->{$name}(...$arguments));
     }
 }

--- a/src/Browser/Session/AutoWait.php
+++ b/src/Browser/Session/AutoWait.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the zenstruck/browser package.
+ *
+ * (c) Kevin Bond <kevinbond@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Zenstruck\Browser\Session;
+
+use Behat\Mink\Exception\ExpectationException;
+
+/**
+ * Retries an operation until it succeeds or the timeout expires.
+ *
+ * Whole operations are retried, never the individual element lookups inside them: a lookup that
+ * waited would invert the meaning of the "not" assertions, and would make each miss of a
+ * speculative lookup (see Browser::getClickableElement()) cost the full timeout.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ *
+ * @internal
+ */
+final class AutoWait
+{
+    /**
+     * Turbo swaps a body in tens of milliseconds: polling any slower spends most of the wait
+     * asleep after the page has already caught up.
+     */
+    private const POLL_INTERVAL = 50_000;
+
+    /**
+     * @param int $timeout milliseconds, 0 or less to disable
+     */
+    public function __construct(private int $timeout = 0)
+    {
+    }
+
+    /**
+     * The configured budget, or null when waiting is off.
+     */
+    public function timeout(): ?int
+    {
+        return $this->timeout > 0 ? $this->timeout : null;
+    }
+
+    /**
+     * Retry until the assertion stops failing. "Not" assertions come out right for free: one that
+     * already holds passes on the first attempt, one whose element is on its way out waits for it.
+     */
+    public function assertion(callable $assertion): mixed
+    {
+        $deadline = $this->deadline();
+
+        while (true) {
+            try {
+                return $assertion();
+            } catch (ExpectationException $e) {
+                if (\microtime(true) >= $deadline) {
+                    throw $e;
+                }
+            }
+
+            \usleep(self::POLL_INTERVAL);
+        }
+    }
+
+    /**
+     * Retry until the lookup finds something. The element is only resolved here: acting on it still
+     * goes through Playwright, which applies its own actionability wait.
+     */
+    public function lookup(callable $lookup): mixed
+    {
+        $deadline = $this->deadline();
+
+        while (true) {
+            if ($found = $lookup()) {
+                return $found;
+            }
+
+            if (\microtime(true) >= $deadline) {
+                return $found;
+            }
+
+            \usleep(self::POLL_INTERVAL);
+        }
+    }
+
+    private function deadline(): float
+    {
+        // a timeout of 0 or less puts the deadline in the past, so every operation gets one attempt
+        return \microtime(true) + ($this->timeout / 1000);
+    }
+}

--- a/src/Browser/Session/Driver.php
+++ b/src/Browser/Session/Driver.php
@@ -27,6 +27,7 @@ abstract class Driver extends CoreDriver
 {
     /** @var AbstractBrowser<Request, Response> */
     private AbstractBrowser $client;
+    private AutoWait $autoWait;
     private bool $started = false;
 
     /** @var mixed */
@@ -41,6 +42,20 @@ abstract class Driver extends CoreDriver
     public function __construct(AbstractBrowser $client)
     {
         $this->client = $client;
+        $this->autoWait = new AutoWait();
+    }
+
+    final public function autoWait(): AutoWait
+    {
+        return $this->autoWait;
+    }
+
+    /**
+     * @param int $timeout milliseconds, 0 or less to disable
+     */
+    final public function setAutoWaitTimeout(int $timeout): void
+    {
+        $this->autoWait = new AutoWait($timeout);
     }
 
     /**

--- a/src/Browser/Session/Driver/PlaywrightDriver.php
+++ b/src/Browser/Session/Driver/PlaywrightDriver.php
@@ -29,6 +29,13 @@ use Zenstruck\Browser\Session\Driver;
  */
 final class PlaywrightDriver extends Driver
 {
+    /**
+     * What playwright falls back to when it is not given a timeout.
+     *
+     * @internal
+     */
+    public const PLAYWRIGHT_DEFAULT_TIMEOUT = 30_000;
+
     /** @var array<string,string[]> */
     private array $attachedFiles = [];
 
@@ -128,7 +135,7 @@ final class PlaywrightDriver extends Driver
 
     public function getAttribute($xpath, $name): ?string
     {
-        return $this->locator($xpath)->getAttribute($name);
+        return $this->locator($xpath)->getAttribute($name, ['timeout' => $this->timeout()]);
     }
 
     public function getValue($xpath): string|bool|array|null
@@ -136,7 +143,7 @@ final class PlaywrightDriver extends Driver
         $locator = $this->locator($xpath);
 
         if ('select' === $this->getTagName($xpath)) {
-            if (null !== $locator->getAttribute('multiple')) {
+            if (null !== $locator->getAttribute('multiple', ['timeout' => $this->timeout()])) {
                 return $locator->evaluate('el => Array.from(el.selectedOptions).map(o => o.value)');
             }
 
@@ -144,7 +151,7 @@ final class PlaywrightDriver extends Driver
         }
 
         if ('checkbox' === $this->typeOf($locator)) {
-            return $locator->isChecked() ? ($locator->getAttribute('value') ?? 'on') : null;
+            return $locator->isChecked() ? ($locator->getAttribute('value', ['timeout' => $this->timeout()]) ?? 'on') : null;
         }
 
         if ('radio' === $this->typeOf($locator)) {
@@ -161,7 +168,7 @@ final class PlaywrightDriver extends Driver
         $type = $this->typeOf($locator);
 
         if ('checkbox' === $type) {
-            $value ? $locator->check() : $locator->uncheck();
+            $value ? $locator->check(['timeout' => $this->timeout()]) : $locator->uncheck(['timeout' => $this->timeout()]);
 
             return;
         }
@@ -173,7 +180,7 @@ final class PlaywrightDriver extends Driver
         }
 
         if ('file' === $type) {
-            $locator->setInputFiles((string) $value);
+            $locator->setInputFiles((string) $value, ['timeout' => $this->timeout()]);
 
             return;
         }
@@ -185,22 +192,22 @@ final class PlaywrightDriver extends Driver
                 return;
             }
 
-            $locator->selectOption($value);
+            $locator->selectOption($value, ['timeout' => $this->timeout()]);
 
             return;
         }
 
-        $locator->fill((string) $value);
+        $locator->fill((string) $value, ['timeout' => $this->timeout()]);
     }
 
     public function check($xpath): void
     {
-        $this->locator($xpath)->check();
+        $this->locator($xpath)->check(['timeout' => $this->timeout()]);
     }
 
     public function uncheck($xpath): void
     {
-        $this->locator($xpath)->uncheck();
+        $this->locator($xpath)->uncheck(['timeout' => $this->timeout()]);
     }
 
     public function isChecked($xpath): bool
@@ -226,10 +233,10 @@ final class PlaywrightDriver extends Driver
         }
 
         try {
-            $locator->selectOption($values);
+            $locator->selectOption($values, ['timeout' => $this->timeout()]);
         } catch (\Throwable) {
             // try selecting by visible text
-            $locator->selectOption(['label' => $value]);
+            $locator->selectOption(['label' => $value], ['timeout' => $this->timeout()]);
         }
     }
 
@@ -241,14 +248,14 @@ final class PlaywrightDriver extends Driver
         $locator = $this->locator($xpath);
         $existing = $this->attachedFiles[$xpath] ?? [];
 
-        if ($existing && null === $locator->getAttribute('multiple')) {
+        if ($existing && null === $locator->getAttribute('multiple', ['timeout' => $this->timeout()])) {
             throw new \InvalidArgumentException('Cannot attach multiple files to a non-multiple file field.');
         }
 
         // cast: an SplFileInfo is a valid Browser::attachFile() argument but Playwright needs a path
         $this->attachedFiles[$xpath] = $files = [...$existing, (string) $path];
 
-        $locator->setInputFiles($files);
+        $locator->setInputFiles($files, ['timeout' => $this->timeout()]);
     }
 
     public function click($xpath): void
@@ -256,7 +263,7 @@ final class PlaywrightDriver extends Driver
         $this->downloadedContent = null;
 
         $this->wrapRequest(function() use ($xpath): void {
-            $this->locator($xpath)->click();
+            $this->locator($xpath)->click(['timeout' => $this->timeout()]);
             $this->page()->waitForLoadState();
         });
     }
@@ -267,7 +274,7 @@ final class PlaywrightDriver extends Driver
 
         $before = $this->page()->url();
 
-        $this->locator($xpath)->dblclick();
+        $this->locator($xpath)->dblclick(['timeout' => $this->timeout()]);
 
         $this->awaitPossibleNavigation($before);
     }
@@ -278,7 +285,7 @@ final class PlaywrightDriver extends Driver
 
         $before = $this->page()->url();
 
-        $this->locator($xpath)->click(['button' => 'right']);
+        $this->locator($xpath)->click(['button' => 'right', 'timeout' => $this->timeout()]);
 
         $this->awaitPossibleNavigation($before);
     }
@@ -342,9 +349,21 @@ final class PlaywrightDriver extends Driver
         return $this->page()->locator('xpath='.$xpath);
     }
 
+    /**
+     * Playwright is never told a default, so every call that can wait is given this explicitly.
+     * Its own default stands in when auto waiting is off.
+     *
+     * @todo click()/fill() run a private actionability check on a hardcoded 30s that no option
+     *       reaches; harmless while the element is resolved before we get here
+     */
+    private function timeout(): int
+    {
+        return $this->autoWait()->timeout() ?? self::PLAYWRIGHT_DEFAULT_TIMEOUT;
+    }
+
     private function typeOf(LocatorInterface $locator): string
     {
-        return \mb_strtolower((string) $locator->getAttribute('type'));
+        return \mb_strtolower((string) $locator->getAttribute('type', ['timeout' => $this->timeout()]));
     }
 
     private function lastResponseBody(): string

--- a/src/Browser/Test/HasBrowser.php
+++ b/src/Browser/Test/HasBrowser.php
@@ -192,6 +192,7 @@ trait HasBrowser
             'console_log_dir' => $_SERVER['BROWSER_CONSOLE_LOG_DIR'] ?? './var/browser/console-logs',
             'follow_redirects' => (bool) ($_SERVER['BROWSER_FOLLOW_REDIRECTS'] ?? true),
             'catch_exceptions' => (bool) ($_SERVER['BROWSER_CATCH_EXCEPTIONS'] ?? true),
+            'default_timeout' => $_SERVER['BROWSER_DEFAULT_TIMEOUT'] ?? null,
         ]);
 
         BrowserExtension::registerBrowser($browser);

--- a/tests/Fixture/files/javascript.html
+++ b/tests/Fixture/files/javascript.html
@@ -30,6 +30,11 @@
 <div style="display: none" id="timeout-box">Contents of timeout box</div>
 <hr>
 
+<h1>Auto Wait Test</h1>
+<div id="late-host"></div>
+<div id="doomed">Contents of doomed box</div>
+<hr>
+
 <h1>Console Log Test</h1>
 <button id="log-error">log error</button>
 <button id="throw-error">throw error</button>
@@ -51,6 +56,15 @@
 
         window.setTimeout(function() {
             $('#timeout-box').show();
+        }, 500);
+
+        window.setTimeout(function() {
+            $('#late-host').append(
+                $('<button>').attr('id', 'late-button').text('late button')
+                    .click(function() { $('#output').text('late clicked'); }),
+                $('<input type="text">').attr('id', 'late-input')
+            );
+            $('#doomed').remove();
         }, 500);
 
         $('#show').click(function() {

--- a/tests/PlaywrightBrowserTest.php
+++ b/tests/PlaywrightBrowserTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Assert;
 use Zenstruck\Browser\PlaywrightBrowser;
 use Zenstruck\Browser\Test\HasBrowser;
 use Zenstruck\Browser\Test\LegacyExtension;
@@ -147,6 +148,135 @@ class PlaywrightBrowserTest extends KernelTestCase
             ->waitUntilNotSeeIn('#output', 'some text')
             ->assertNotSeeIn('#output', 'some text')
         ;
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function actions_wait_for_elements_that_are_not_there_yet(): void
+    {
+        // #late-button and #late-input only appear 500ms after load
+        $this->browser()
+            ->visit('/javascript')
+            ->fillField('late-input', 'typed')
+            ->click('late button')
+            ->assertSeeIn('#output', 'late clicked')
+        ;
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function assertions_wait_for_elements_that_are_not_there_yet(): void
+    {
+        $this->browser()
+            ->visit('/javascript')
+            ->assertSeeElement('#late-button')
+            ->assertSee('late button')
+            ->assertElementCount('#late-button', 1)
+        ;
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function negative_assertions_wait_for_the_element_to_go_away(): void
+    {
+        // #doomed is removed 500ms after load
+        $this->browser()
+            ->visit('/javascript')
+            ->assertNotSeeElement('#doomed')
+            ->assertNotSee('Contents of doomed box')
+        ;
+    }
+
+    /**
+     * A "not" assertion that already holds must not sit through the timeout waiting for something
+     * that was never going to appear.
+     *
+     * @test
+     */
+    #[Test]
+    public function negative_assertions_that_already_hold_return_immediately(): void
+    {
+        $_SERVER['BROWSER_DEFAULT_TIMEOUT'] = '5000';
+
+        try {
+            $start = \hrtime(true);
+
+            $this->browser()
+                ->visit('/javascript')
+                ->assertNotSeeElement('#never-exists')
+                ->assertElementCount('#never-exists', 0)
+            ;
+
+            $this->assertLessThan(2.0, (\hrtime(true) - $start) / 1e9);
+        } finally {
+            unset($_SERVER['BROWSER_DEFAULT_TIMEOUT']);
+        }
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function the_timeout_can_be_changed_at_runtime(): void
+    {
+        $browser = $this->browser()
+            ->visit('/javascript')
+            // the element needs 500ms, so a 100ms budget must give up before it arrives
+            ->timeout(100)
+        ;
+
+        Assert::that(static fn() => $browser->assertSeeElement('#late-button'))
+            ->throws(AssertionFailedError::class)
+        ;
+
+        $browser
+            ->timeout(5000)
+            ->assertSeeElement('#late-button')
+        ;
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function the_timeout_cannot_be_zero_or_negative(): void
+    {
+        $browser = $this->browser();
+
+        Assert::that(static fn() => $browser->timeout(0))
+            ->throws(\InvalidArgumentException::class, 'Timeout must be a positive number of milliseconds, "0" given.')
+        ;
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function the_auto_wait_timeout_is_configurable(): void
+    {
+        $_SERVER['BROWSER_DEFAULT_TIMEOUT'] = '250';
+
+        try {
+            $browser = $this->browser()->visit('/javascript');
+
+            // time the assertion alone, navigation is not part of the budget under test
+            $start = \hrtime(true);
+
+            Assert::that(static fn() => $browser->assertSeeElement('#late-button'))
+                ->throws(AssertionFailedError::class)
+            ;
+
+            // the element needs 500ms: a 250ms budget must give up before it arrives
+            $this->assertLessThan(0.5, (\hrtime(true) - $start) / 1e9);
+        } finally {
+            unset($_SERVER['BROWSER_DEFAULT_TIMEOUT']);
+        }
     }
 
     /**


### PR DESCRIPTION
Actions and assertions now wait for the page to catch up, so `waitUntil*()` is rarely needed. Clicking or filling waits for the element to appear, assertions retry until they pass, and "not" assertions pass as soon as they hold. Everything gives up after `BROWSER_DEFAULT_TIMEOUT` (2 second default) and fails as before.

This helps most with Turbo, where visits, frames and streams all update the page without a navigation to wait on - assertions following a Turbo-driven click, or a stream broadcast that arrives on its own, simply wait for the new content to land.

Only `PlaywrightBrowser` is affected - `KernelBrowser` and `PantherBrowser` behave exactly as they did. Page loads keep Playwright's 30 second limit, since a cold kernel boot is far slower than anything an assertion should wait for.

The trade is that an assertion destined to fail can only be reported once the timeout expires, so failures cost 2 seconds (default) instead of returning instantly. `timeout()` adjusts it per test.

Closes #199. Supersedes #208.
