### PR TITLE
feat: inject the http session into use()

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,38 @@ $browser
 ;
 ```
 
+#### Session
+
+The _KernelBrowser_ can inject your app's http session into `->use()`, to read what
+the app stored or to set something up before making a request:
+
+```php
+/** @var \Zenstruck\Browser\KernelBrowser $browser **/
+
+$browser
+    ->use(function(\Symfony\Component\HttpFoundation\Session\SessionInterface $session) {
+        // seed the session before any request is made
+        $session->set('cart', ['product-1']);
+    })
+    ->visit('/cart')
+    ->assertSee('product-1')
+
+    ->use(function(\Symfony\Component\HttpFoundation\Session\SessionInterface $session) {
+        // read what the app stored
+        $this->assertSame(['product-1', 'product-2'], $session->get('cart'));
+    })
+;
+```
+
+The session is loaded from the session cookie if the browser already has one, so the
+id is preserved and nothing the app stored is lost. It is saved, and its cookie
+written, when the callback returns.
+
+> [!NOTE]
+> This requires the session to be enabled in your app, and a session storage that the
+> test process can write to, typically `session.storage.factory.mock_file` in the test
+> environment.
+
 #### HTTP Requests
 
 The _KernelBrowser_ can be used for testing API endpoints. The following http methods are available:

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -478,6 +478,8 @@ abstract class Browser
             Parameter::union(...$this->useParameters()),
         );
 
+        $this->afterUse();
+
         return $this;
     }
 
@@ -862,6 +864,15 @@ abstract class Browser
                 Assert::fail('DataCollector %s is not available for this request.', [$class]);
             })),
         ];
+    }
+
+    /**
+     * Called after a {@see use()} callback has run, to flush anything it was handed.
+     *
+     * @internal
+     */
+    protected function afterUse(): void
+    {
     }
 
     private function container(): ?ContainerInterface

--- a/src/Browser/KernelBrowser.php
+++ b/src/Browser/KernelBrowser.php
@@ -12,6 +12,8 @@
 namespace Zenstruck\Browser;
 
 use Symfony\Bundle\FrameworkBundle\KernelBrowser as SymfonyKernelBrowser;
+use Symfony\Component\BrowserKit\Cookie;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Zenstruck\Browser;
 use Zenstruck\Browser\Session\Driver\BrowserKitDriver;
 use Zenstruck\Callback\Parameter;
@@ -26,6 +28,8 @@ use Zenstruck\Callback\Parameter;
 class KernelBrowser extends Browser
 {
     protected ?HttpOptions $defaultHttpOptions = null;
+
+    private ?SessionInterface $httpSession = null;
 
     /**
      * @internal
@@ -203,6 +207,48 @@ class KernelBrowser extends Browser
         return [
             ...parent::useParameters(),
             Parameter::typed(Json::class, Parameter::factory(fn() => $this->json())),
+            Parameter::typed(SessionInterface::class, Parameter::factory(fn() => $this->httpSession())),
         ];
+    }
+
+    protected function afterUse(): void
+    {
+        if (null === $session = $this->httpSession) {
+            return;
+        }
+
+        $this->httpSession = null;
+
+        $session->save();
+
+        // the cookie is left without a domain on purpose: the jar sends a domain-less
+        // cookie to any host, so this works whatever host the browser then visits
+        $this->cookieJar()->set(new Cookie($session->getName(), $session->getId()));
+    }
+
+    /**
+     * The session the next request will use, loaded from the session cookie if there is one.
+     *
+     * It is saved, and its cookie written, once the {@see use()} callback returns.
+     */
+    private function httpSession(): SessionInterface
+    {
+        if (null !== $this->httpSession) {
+            return $this->httpSession;
+        }
+
+        if (!($container = $this->client()->getContainer())->has('session.factory')) {
+            throw new \LogicException('Sessions are not available/enabled.');
+        }
+
+        $session = $container->get('session.factory')->createSession();
+
+        if (null !== $cookie = $this->cookieJar()->get($session->getName())) {
+            $session->setId($cookie->getValue());
+        }
+
+        $session->start();
+
+        return $this->httpSession = $session;
     }
 }

--- a/tests/Fixture/Kernel.php
+++ b/tests/Fixture/Kernel.php
@@ -51,6 +51,11 @@ final class Kernel extends BaseKernel
         return new Response('success');
     }
 
+    public function readSession(Request $request): Response
+    {
+        return new Response($request->getSession()->get('key') ?? '(none)');
+    }
+
     public function text(): Response
     {
         return new Response('text content', 200, ['Content-Type' => 'text/plain']);
@@ -217,6 +222,7 @@ final class Kernel extends BaseKernel
     {
         $routes->add('page1', '/page1')->controller('kernel::page1');
         $routes->add('page2', '/page2')->controller('kernel::page2');
+        $routes->add('read-session', '/read-session')->controller('kernel::readSession');
         $routes->add('text', '/text')->controller('kernel::text');
         $routes->add('submit-form', '/submit-form')->controller('kernel::submitForm');
         $routes->add('http-method', '/http-method')->controller('kernel::httpMethod');

--- a/tests/KernelBrowserTests.php
+++ b/tests/KernelBrowserTests.php
@@ -13,6 +13,8 @@ namespace Zenstruck\Browser\Tests;
 
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\BrowserKit\CookieJar;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Zenstruck\Browser\HttpOptions;
 use Zenstruck\Browser\Json;
 use Zenstruck\Browser\KernelBrowser;
@@ -24,6 +26,102 @@ use Zenstruck\Browser\Tests\Fixture\CustomHttpOptions;
 trait KernelBrowserTests
 {
     use BrowserTests;
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function can_write_to_the_session_before_making_a_request(): void
+    {
+        $this->browser()
+            ->use(function(SessionInterface $session) {
+                $session->set('key', 'set by the test');
+            })
+            ->visit('/read-session')
+            ->assertContains('set by the test')
+        ;
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function can_read_the_session_written_by_the_application(): void
+    {
+        $this->browser()
+            ->visit('/page1?start-session=1')
+            ->use(function(SessionInterface $session) {
+                $this->assertSame('value', $session->get('key'));
+            })
+        ;
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function session_written_by_the_test_is_visible_to_the_application_and_back(): void
+    {
+        $this->browser()
+            ->visit('/page1?start-session=1')
+            ->use(function(SessionInterface $session) {
+                $this->assertSame('value', $session->get('key'));
+
+                $session->set('key', 'overwritten');
+            })
+            ->visit('/read-session')
+            ->assertContains('overwritten')
+            ->use(function(SessionInterface $session) {
+                $this->assertSame('overwritten', $session->get('key'));
+            })
+        ;
+    }
+
+    /**
+     * The session id must not change when the test only reads or updates it, otherwise
+     * anything the application had stored under the previous id would be dropped.
+     *
+     * @test
+     */
+    #[Test]
+    public function using_the_session_keeps_the_existing_session_cookie(): void
+    {
+        $id = null;
+
+        $this->browser()
+            ->visit('/page1?start-session=1')
+            ->use(function(CookieJar $jar) use (&$id) {
+                $id = $jar->get('MOCKSESSID')?->getValue();
+
+                $this->assertNotNull($id);
+            })
+            ->use(function(SessionInterface $session) use (&$id) {
+                $this->assertSame($id, $session->getId());
+
+                $session->set('key', 'still the same session');
+            })
+            ->use(function(CookieJar $jar) use (&$id) {
+                $this->assertSame($id, $jar->get('MOCKSESSID')?->getValue());
+            })
+            ->visit('/read-session')
+            ->assertContains('still the same session')
+        ;
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
+    public function session_started_by_the_test_is_available_on_any_host(): void
+    {
+        $this->browser()
+            ->use(function(SessionInterface $session) {
+                $session->set('key', 'no domain on the cookie');
+            })
+            ->visit('http://example.test/read-session')
+            ->assertContains('no domain on the cookie')
+        ;
+    }
 
     /**
      * @test


### PR DESCRIPTION
Closes #149

This is the API you sketched in the issue:

```php
$browser
    ->use(function(SessionInterface $session) {
        $session->set('cart', ['product-1']);
    })
    ->visit('/cart')
    ->assertSee('product-1')
;
```

It is on `KernelBrowser` only, not on `Browser`, since it needs the app's container and the test process's cookie jar. Panther and Playwright drive a real server, so the same trick does not apply there.

**The one change outside `KernelBrowser`** is a hook: `use()` now calls a no-op `protected afterUse()` after the callback. It is needed because the session has to be saved *after* the callback has mutated it, and `Callback::invokeAll()` gives no point to do that. The alternative was to hand out a save-through decorator, which I dropped: it would not be a real `Session` any more, so `getFlashBag()` and `instanceof Session` would break. Handing out the real object seemed worth the five line seam, but say the word if you would rather have it another way.

Things I measured rather than assumed:

- **The session cookie is written without a domain.** `CookieJar::allValues()` skips the domain check entirely when the cookie has none (`if ($domain)`), so it is sent whatever host is visited. That avoids guessing a host, which cannot be done anyway before the first request: `getCurrentUrl()` throws `Unable to access the request before visiting a page` on a fresh browser. A test covers a non-`localhost` host.
- **The id is preserved.** If the jar already has a session cookie, its value becomes the session id, so nothing the app stored is dropped. `using_the_session_keeps_the_existing_session_cookie` asserts the id is the same before and after.
- **Saving twice is safe.** I checked that `set()` after a `save()` works and persists, which is what happens when a test uses the session in two separate `->use()` calls.

The round trip goes both ways in the tests: the app reads what the test wrote (new `/read-session` route on the test kernel), and the test reads what the app wrote (the existing `/page1?start-session=1`).

When sessions are not enabled, `httpSession()` throws `Sessions are not available/enabled.`, matching the wording of the existing `securityToken()` guard.

280 tests green, PHPStan clean. I could not run php-cs-fixer locally, it is not in the dev deps, so the bot may still have something to fix.
