### PR TITLE
feat: accept many selectors in assertSeeIn() and assertNotSeeIn()

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ $browser
     ->assertNotSee('some text')
     ->assertSeeIn('h1', 'some text')
     ->assertNotSeeIn('h1', 'some text')
+
+    // pass many selectors to check the same text in each of them
+    ->assertSeeIn(['title', 'h1'], 'some text')
+    ->assertNotSeeIn(['title', 'h1'], 'some text')
     ->assertSeeElement('h1')
     ->assertNotSeeElement('h1')
     ->assertElementCount('ul li', 2)

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -149,21 +149,29 @@ abstract class Browser
     }
 
     /**
+     * @param string|iterable<string> $selector One or many css selectors, all of which must contain the text
+     *
      * @return static
      */
-    final public function assertSeeIn(string $selector, string $expected): self
+    final public function assertSeeIn(string|iterable $selector, string $expected): self
     {
-        $this->session()->assert()->elementTextContains('css', $selector, $expected);
+        foreach (self::normalizeSelectors($selector) as $css) {
+            $this->session()->assert()->elementTextContains('css', $css, $expected);
+        }
 
         return $this;
     }
 
     /**
+     * @param string|iterable<string> $selector One or many css selectors, none of which may contain the text
+     *
      * @return static
      */
-    final public function assertNotSeeIn(string $selector, string $expected): self
+    final public function assertNotSeeIn(string|iterable $selector, string $expected): self
     {
-        $this->session()->assert()->elementTextNotContains('css', $selector, $expected);
+        foreach (self::normalizeSelectors($selector) as $css) {
+            $this->session()->assert()->elementTextNotContains('css', $css, $expected);
+        }
 
         return $this;
     }
@@ -878,5 +886,15 @@ abstract class Browser
         }
 
         return $container->get('security.token_storage')->getToken();
+    }
+
+    /**
+     * @param string|iterable<string> $selector
+     *
+     * @return iterable<string>
+     */
+    private static function normalizeSelectors(string|iterable $selector): iterable
+    {
+        return \is_string($selector) ? [$selector] : $selector;
     }
 }

--- a/tests/BrowserTests.php
+++ b/tests/BrowserTests.php
@@ -938,6 +938,35 @@ trait BrowserTests
      * @test
      */
     #[Test]
+    public function see_in_assertions_accept_many_selectors(): void
+    {
+        $this->browser()
+            ->visit('/page1')
+            ->assertSeeIn(['h1', 'body'], 'h1 title')
+            ->assertNotSeeIn(['h1', 'title'], 'invalid text')
+        ;
+
+        // every selector must match, so one that does not fails the assertion
+        Assert::that(function() {
+            $this->browser()
+                ->visit('/page1')
+                ->assertSeeIn(['h1', 'title'], 'h1 title')
+            ;
+        })->throws(AssertionFailedError::class);
+
+        // and none may match for the negative one
+        Assert::that(function() {
+            $this->browser()
+                ->visit('/page1')
+                ->assertNotSeeIn(['title', 'h1'], 'h1 title')
+            ;
+        })->throws(AssertionFailedError::class);
+    }
+
+    /**
+     * @test
+     */
+    #[Test]
     public function html_head_assertions(): void
     {
         $this->browser()


### PR DESCRIPTION
Closes #16.

`assertSeeIn()` and `assertNotSeeIn()` now also take an iterable of selectors, exactly as sketched in the issue. Every selector must contain the text for the positive assertion, and none may for the negative one.

`assertNotSeeIn()` was not part of the request. I did it anyway because leaving the pair asymmetric would be surprising, happy to drop it if you would rather keep the change minimal.

The README's opening example is the case from the issue, two consecutive `assertSeeIn` with the same expected text, so I left it alone and documented the new form in the assertion list instead. Say the word if you want the headline example switched over too.
